### PR TITLE
Ignoring parameters tagged with file-ext-override.

### DIFF
--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/config/reader/handler/ParamHandler.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/config/reader/handler/ParamHandler.java
@@ -93,6 +93,8 @@ public class ParamHandler extends DefaultHandler {
 	private static String ATTR_ADVANCED = "advanced";
 	private static String ATTR_REQUIRED = "required";
 
+	private static String TAG_VALUE_FILE_EXT_OVERRIDE = "file-ext-override";
+
 	// is contained in the schema but currently we do not handle this tag
 	@SuppressWarnings("unused")
 	private static String ATTR_OUTPUT_FORMAT_SOURCE = "output_format_source";
@@ -262,6 +264,10 @@ public class ParamHandler extends DefaultHandler {
 		// set flags for parameter
 		m_currentParameter.setAdvanced(isAdvanced(attributes));
 		m_currentParameter.setIsOptional(isOptional(attributes));
+
+		// check whether the parameter is to be ignored (has tag file-ext-override).
+		Set<String> tags = getTags(attributes);
+		m_currentParameter.setIsIgnored(tags.contains(TAG_VALUE_FILE_EXT_OVERRIDE));
 
 		// extract the description
 		String description = attributes.getValue(ATTR_DESCRIPTION);

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/CLICommandGenerator.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/CLICommandGenerator.java
@@ -194,6 +194,8 @@ public class CLICommandGenerator implements ICommandGenerator {
 						extractedParameterValues.add(((ListParameter) p)
 								.getStrings());
 					} else {
+						if (p.isIgnored())
+							continue;  // Ignored parameters are not passed to CLI.
 						List<String> l = new ArrayList<String>();
 						l.add(p.getStringRep());
 						extractedParameterValues.add(l);

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/parameter/Parameter.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/parameter/Parameter.java
@@ -67,6 +67,11 @@ public abstract class Parameter<T> implements Serializable {
 	private boolean advanced;
 
 	/**
+	 * Flag indicating if the parameter is to be ignored.
+	 */
+	private boolean isIgnored;
+
+	/**
 	 * Constructor with unique key of parameter and generic value to store.
 	 * 
 	 * @param key
@@ -82,6 +87,7 @@ public abstract class Parameter<T> implements Serializable {
 		this.setSection("default");
 		this.setIsOptional(true);
 		this.setAdvanced(false);
+		this.setIsIgnored(false);
 	}
 
 	/**
@@ -260,4 +266,20 @@ public abstract class Parameter<T> implements Serializable {
 	 */
 	public static String SEPARATOR_TOKEN = "@@@__@@@";
 
+	/**
+	 * Return whether the parameter is to be ignored.
+	 */
+	public boolean isIgnored() {
+		return this.isIgnored;
+	}
+
+	/**
+	 * Sets whether the parameter is to be ignored (is the case if tagged with
+	 * "file-ext-override).
+	 *
+	 * @param val The new "is ignored" value.
+	 */
+	public void setIsIgnored(boolean val) {
+		this.isIgnored = val;
+	}
 }


### PR DESCRIPTION
Naive patch that ignores all parameters tagged with "file-ext-overview" when calling the program.

However, these nodes should probably be ignored completely when loading the XML file.

In the meantime, this patch allows to run the current SeqAn apps as KNIME nodes.
