### PR TITLE
This avoids appending extra extensions

### DIFF
--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -544,9 +544,11 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         for (int i = 0; i < nOut; i++) {
             Port port = m_nodeConfig.getOutputPorts().get(i);
             String name = port.getName();
-            String ext = getOutputType(i);
+            String ext = "";
             boolean isPrefix = port.isPrefix();
-
+            if (!isPrefix){
+                ext = getOutputType(i);
+            }
             Parameter<?> p = m_nodeConfig.getParameter(name);
 
             // basenames and number of output files guessed from input
@@ -596,8 +598,10 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
                 }
 
                 // create basename: <base_name>_<outfile_nr>
-                String fileName = basename + '.' + ext;
-
+                String fileName = basename;
+                if (!isPrefix){
+                    fileName += '.' + ext;
+                }
                 if (isPrefix) {
                     FileStorePrefixURIPortObject fspup = new FileStorePrefixURIPortObject(
                             exec.createFileStore(m_nodeConfig.getName() + "_"


### PR DESCRIPTION
A prefix can represent files with various extensions and/or mimetypes. As a result one can not specify in advance supported file types for an input/output prefix ports. Which means supported files are any files with that prefix. Something like "prefix.\* " ....
This fix avoids extra extension taken from the valid types and enables us to use ".*" as a valid type  and closes the issue I reported issue #115.

Before it looked like these.

```
/path/to/prefix.ext.ext1 
/path/to/prefix.ext.ext2 
/path/to/prefix.ext.ext3 ... 
```

now 

```
/path/to/prefix.ext1 
/path/to/prefix.ext2 
/path/to/prefix.ext3 ... 
```
