### PR TITLE
Docker extension

### DIFF
--- a/com.genericworkflownodes.knime.config/src/com/genericworkflownodes/util/Helper.java
+++ b/com.genericworkflownodes.knime.config/src/com/genericworkflownodes/util/Helper.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2011, Marc Röttig, Stephan Aiche.
+ * Copyright (c) 2016, Benjamin Schubert.
  *
  * This file is part of GenericKnimeNodes.
  * 
@@ -34,7 +35,7 @@ import java.util.Random;
 /**
  * Collection of Helper methods.
  * 
- * @author roettig, aiche
+ * @author roettig, aiche, schubert
  */
 public final class Helper {
 
@@ -42,6 +43,8 @@ public final class Helper {
      * Size of the buffer when copying streams to files.
      */
     private static final int BUFFER_SIZE = 2048;
+	private static final String OS_WIN = "Windows";
+	private static final String OS_MAC = "Mac";
 
     /**
      * Private c'tor to avoid instantiation of Util class.
@@ -197,8 +200,8 @@ public final class Helper {
      */
     public static synchronized File getTempDir(final String prefix,
             boolean autodelete) throws IOException {
-        return getTempDir(System.getProperty("java.io.tmpdir"), prefix,
-                autodelete);
+    	return getTempDir(System.getProperty("java.io.tmpdir"), prefix,
+    				autodelete);
     }
 
     /**
@@ -279,5 +282,29 @@ public final class Helper {
             target[i] = new String[src[i].length];
             System.arraycopy(src[i], 0, target[i], 0, array_length);
         }
+    }
+    
+    /***
+     * Checks if OS is specific OS family
+     * @return
+     */
+    private static boolean isOS(final String osName) {
+        return System.getProperty("os.name").startsWith(osName);
+    }
+    
+    /**
+     * Checks if OS is part of the Windows-Family
+     * @return
+     */
+    public static boolean isWin(){
+    	return isOS(OS_WIN);
+    }
+    
+    /**
+     * Checks if OS is part of the Mac-Family
+     * @return
+     */
+     public static boolean isMac(){
+    	return isOS(OS_MAC);
     }
 }

--- a/com.genericworkflownodes.knime.node_generator/src/com/genericworkflownodes/knime/nodegeneration/model/directories/NodesSourceDirectory.java
+++ b/com.genericworkflownodes.knime.node_generator/src/com/genericworkflownodes/knime/nodegeneration/model/directories/NodesSourceDirectory.java
@@ -136,6 +136,16 @@ public class NodesSourceDirectory extends Directory {
         return properties.getProperty(key, defaultValue);
     }
 
+    public Properties getToolProperites(){
+    	Properties p = new Properties();
+    	for(String key : properties.stringPropertyNames()) {
+    		if(key.startsWith("tool.")){
+    			p.put(key, properties.get(key));
+    		}
+    	}
+    	return p;
+    }
+    
     public List<CTDFile> getCtdFiles() {
         return descriptorsDirectory.getCTDFiles();
     }

--- a/com.genericworkflownodes.knime.node_generator/src/com/genericworkflownodes/knime/nodegeneration/templates/knime_node/NodeDockerModel.template
+++ b/com.genericworkflownodes.knime.node_generator/src/com/genericworkflownodes/knime/nodegeneration/templates/knime_node/NodeDockerModel.template
@@ -1,0 +1,26 @@
+// THIS CODE WAS GENERATED WITH THE GENERIC WORKFLOW NODES FOR KNIME NODE GENERATOR
+// DO NOT MODIFY
+package __BASE__.knime.nodes.__NODENAME__;
+
+import com.genericworkflownodes.knime.generic_node.GenericKnimeNodeModel;
+
+import org.knime.core.node.InvalidSettingsException;
+
+import com.genericworkflownodes.knime.config.INodeConfiguration;
+import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
+
+/**
+    @brief __NODENAME__ Node Model.
+*/
+public class __NODENAME__NodeModel extends GenericKnimeNodeModel {  
+    protected __NODENAME__NodeModel(INodeConfiguration nodeConfig,
+            IPluginConfiguration pluginConfig) {
+        super(nodeConfig, pluginConfig, new String[][]{__INCLAZZEZ__}, new String[][]{__OUTCLAZZEZ__});
+    }
+    
+    @Override
+    protected void checkIfToolExists() 
+    	throws InvalidSettingsException {
+    
+    }
+}

--- a/com.genericworkflownodes.knime.node_generator/src/com/genericworkflownodes/knime/nodegeneration/templates/knime_node/NodeModelTemplate.java
+++ b/com.genericworkflownodes.knime.node_generator/src/com/genericworkflownodes/knime/nodegeneration/templates/knime_node/NodeModelTemplate.java
@@ -11,10 +11,10 @@ import com.genericworkflownodes.knime.port.Port;
 public class NodeModelTemplate extends Template {
 
     public NodeModelTemplate(String packageName, String nodeName,
-            INodeConfiguration nodeConfiguration) throws IOException,
+            INodeConfiguration nodeConfiguration, String nodeTemplate) throws IOException,
             UnknownMimeTypeException {
         super(NodeGenerator.class
-                .getResourceAsStream("templates/knime_node/NodeModel.template"));
+                .getResourceAsStream("templates/knime_node/"+nodeTemplate));
 
         replace("__BASE__", packageName);
         replace("__NODENAME__", nodeName);

--- a/com.genericworkflownodes.knime/plugin.xml
+++ b/com.genericworkflownodes.knime/plugin.xml
@@ -92,7 +92,7 @@
             name="OpenMSCommandGenerator">
       </commandgenerator>
       <commandgenerator
-            class="com.genericworkflownodes.knime.execution.impl.OpenMSCommandGenerator"
+            class="com.genericworkflownodes.knime.execution.impl.DockerCommandGenerator"
             name="DockerCommandGenerator">
       </commandgenerator>
    </extension>

--- a/com.genericworkflownodes.knime/plugin.xml
+++ b/com.genericworkflownodes.knime/plugin.xml
@@ -92,7 +92,7 @@
             name="OpenMSCommandGenerator">
       </commandgenerator>
       <commandgenerator
-            class="com.genericworkflownodes.knime.execution.impl.DockerCommandGenerator"
+            class="com.genericworkflownodes.knime.execution.impl.OpenMSCommandGenerator"
             name="DockerCommandGenerator">
       </commandgenerator>
    </extension>

--- a/com.genericworkflownodes.knime/plugin.xml
+++ b/com.genericworkflownodes.knime/plugin.xml
@@ -40,6 +40,7 @@
    
    <extension point="org.eclipse.ui.preferencePages">
       <page category="org.knime.workbench.ui.preferences" class="com.genericworkflownodes.knime.preferences.PreferencePage" id="com.genericworkflownodes.knime.preferences.PreferencePage" name="Generic KNIME Nodes"/>
+      <page category="org.knime.workbench.ui.preferences" class="com.genericworkflownodes.knime.preferences.DockerMachinePreferencePage" id="com.genericworkflownodes.knime.preferences.com.genericworkflownodes.knime.preferences.DockerMachinePreferencePage" name="GKN Docker"/>
    </extension>
    <extension
          point="com.genericworkflownodes.knime.execution.Executor">
@@ -50,6 +51,14 @@
       <executor
             class="com.genericworkflownodes.knime.execution.impl.LocalToolExecutor"
             name="LocalToolExecutor">
+      </executor>
+      <executor
+            class="com.genericworkflownodes.knime.execution.impl.LocalDockerToolExecutor"
+            name="com.genericworkflownodes.knime.execution.impl.LocalDockerToolExecutor">
+      </executor>
+      <executor
+            class="com.genericworkflownodes.knime.execution.impl.LocalDockerToolExecutor"
+            name="LocalDockerToolExecutor">
       </executor>
    </extension>
    <extension
@@ -67,6 +76,10 @@
             name="com.genericworkflownodes.knime.execution.impl.OpenMSCommandGenerator">
       </commandgenerator>
       <commandgenerator
+            class="com.genericworkflownodes.knime.execution.impl.DockerCommandGenerator"
+            name="com.genericworkflownodes.knime.execution.impl.DockerCommandGenerator">
+      </commandgenerator>
+      <commandgenerator
             class="com.genericworkflownodes.knime.execution.impl.BALLCommandGenerator"
             name="BALLCommandGenerator">
       </commandgenerator>
@@ -78,5 +91,12 @@
             class="com.genericworkflownodes.knime.execution.impl.OpenMSCommandGenerator"
             name="OpenMSCommandGenerator">
       </commandgenerator>
+      <commandgenerator
+            class="com.genericworkflownodes.knime.execution.impl.DockerCommandGenerator"
+            name="DockerCommandGenerator">
+      </commandgenerator>
+   </extension>
+   <extension
+         point="com.genericworkflownodes.knime.execution.CommandGenerator">
    </extension>
 </plugin>

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/GenericNodesPlugin.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/GenericNodesPlugin.java
@@ -22,6 +22,8 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.knime.core.node.NodeLogger;
 import org.osgi.framework.BundleContext;
 
+import com.genericworkflownodes.util.Helper;
+
 /**
  * This is the OSGI bundle activator.
  * 
@@ -45,6 +47,16 @@ public class GenericNodesPlugin extends AbstractUIPlugin {
      */
     private static boolean isDebugModeEnabled = false;
 
+    /**
+     * The Docker installation directory
+     */
+    private static String dockerInstallationDir = "";
+    
+    /**
+     * The VM installation directory used by docker-machine
+     */
+    private static String vmInstllationDir = "";
+    
     /**
      * Check if the plug-in is in isDebugModeEnabled mode.
      * 
@@ -76,6 +88,16 @@ public class GenericNodesPlugin extends AbstractUIPlugin {
     @Override
     public void start(final BundleContext context) throws Exception {
         super.start(context);
+        if (Helper.isWin()) {
+            GenericNodesPlugin.setDockerInstallationDir("C:\\Program Files\\Docker Toolbox");
+            GenericNodesPlugin.setVmInstllationDir("C:\\Program Files\\Oracle\\VirtualBox");
+        } else if (Helper.isMac()) {
+            GenericNodesPlugin.setDockerInstallationDir( "/usr/local/bin");
+            GenericNodesPlugin.setVmInstllationDir("/usr/local/bin");
+        } else{
+            GenericNodesPlugin.setDockerInstallationDir( "/usr/bin");
+            GenericNodesPlugin.setVmInstllationDir("/usr/bin");
+        }
         gknPLugin = this;
     }
 
@@ -102,4 +124,33 @@ public class GenericNodesPlugin extends AbstractUIPlugin {
         return gknPLugin;
     }
 
+    /**
+     * @return the dockerInstallationDir
+     */
+    public static String getDockerInstallationDir() {
+        return dockerInstallationDir;
+    }
+
+    /**
+     * @param dockerInstallationDir the dockerInstallationDir to set
+     */
+    public static void setDockerInstallationDir(String dockerInstallationDir) {
+        LOGGER.debug("Setting GKN dockerInstallationDir: " + dockerInstallationDir);
+        GenericNodesPlugin.dockerInstallationDir = dockerInstallationDir;
+    }
+
+    /**
+     * @return the vmInstllationDir
+     */
+    public static String getVmInstllationDir() {
+        return vmInstllationDir;
+    }
+
+    /**
+     * @param vmInstllationDir the vmInstllationDir to set
+     */
+    public static void setVmInstllationDir(String vmInstllationDir) {
+        LOGGER.debug("Setting GKN vmInstllationDir: " + vmInstllationDir);
+        GenericNodesPlugin.vmInstllationDir = vmInstllationDir;
+    }
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IPluginConfiguration.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IPluginConfiguration.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2012, Stephan Aiche.
+ * Copyright (c) 2016, Benjamin Schubert.
  *
  * This file is part of GenericKnimeNodes.
  * 
@@ -23,7 +24,7 @@ import java.util.Properties;
 /**
  * Provides all plugin specific configuration settings.
  * 
- * @author aiche
+ * @author aiche, schubert
  */
 public interface IPluginConfiguration {
 
@@ -55,4 +56,26 @@ public interface IPluginConfiguration {
      * @return The binary manager for this plugin.
      */
     BinaryManager getBinaryManager();
+    
+    /**
+     *  The tool specific properties
+     *  
+     *  @return
+     */
+    Properties getToolProperties(); 
+    
+    /**
+     * Specific tool properties
+     * 
+     * @param toolName - The name of the tool
+     * @return 
+     */
+    Properties getToolProperty(String toolName);
+    
+    /**
+     *  The name of the docker-machine to use
+     *  
+     * @return
+     */
+    String getDockerMachine();
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/CLICommandGenerator.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/CLICommandGenerator.java
@@ -46,7 +46,7 @@ public class CLICommandGenerator implements ICommandGenerator {
     protected static final NodeLogger logger = NodeLogger
             .getLogger(CLICommandGenerator.class);
 
-    private INodeConfiguration nodeConfig;
+    protected INodeConfiguration nodeConfig;
 
     @Override
     public List<String> generateCommands(INodeConfiguration nodeConfiguration,
@@ -81,7 +81,7 @@ public class CLICommandGenerator implements ICommandGenerator {
      * @throws Exception
      *             Is thrown if the configuration values are invalid.
      */
-    private List<String> processCLI() throws Exception {
+    protected List<String> processCLI() throws Exception {
         List<String> commands = new ArrayList<String>();
 
         for (CLIElement cliElement : nodeConfig.getCLI().getCLIElement()) {
@@ -128,7 +128,7 @@ public class CLICommandGenerator implements ICommandGenerator {
      * @param cliElement
      * @param commands
      */
-    private void expandParameters(List<List<String>> extractedParameterValues,
+    protected void expandParameters(List<List<String>> extractedParameterValues,
             CLIElement cliElement, List<String> commands) {
         // since we assume that the outer list is not empty this will always
         // work
@@ -158,7 +158,7 @@ public class CLICommandGenerator implements ICommandGenerator {
      * @throws Exception
      *             If not all contained lists have the same size.
      */
-    private void validateExtractedParameters(
+    protected void validateExtractedParameters(
             List<List<String>> extractedParameterValues) throws Exception {
 
         int currentSize = -1;
@@ -213,7 +213,7 @@ public class CLICommandGenerator implements ICommandGenerator {
      * @param cliElement
      * @return
      */
-    private boolean isMappedToBooleanParameter(CLIElement cliElement) {
+    protected boolean isMappedToBooleanParameter(CLIElement cliElement) {
         return cliElement.getMapping().size() == 1
                 && nodeConfig.getParameter(cliElement.getMapping().get(0)
                         .getReferenceName()) instanceof BoolParameter;
@@ -228,7 +228,7 @@ public class CLICommandGenerator implements ICommandGenerator {
      * @param cliElement
      *            The currently interpreted clielement.
      */
-    private void handleBooleanParameter(List<String> commands,
+    protected void handleBooleanParameter(List<String> commands,
             CLIElement cliElement) {
         if (((BoolParameter) nodeConfig.getParameter(cliElement.getMapping()
                 .get(0).getReferenceName())).getValue()) {
@@ -242,7 +242,7 @@ public class CLICommandGenerator implements ICommandGenerator {
      * @param configStore
      * @throws IOException
      */
-    private void exportPlainConfiguration(File workingDirectory)
+    protected void exportPlainConfiguration(File workingDirectory)
             throws IOException {
         PlainNodeConfigurationWriter writer = new PlainNodeConfigurationWriter();
         writer.init(nodeConfig);

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/DockerCommandGenerator.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/DockerCommandGenerator.java
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2012, Benjamin Schubert.
+ *
+ * This file is part of GenericKnimeNodes.
+ * 
+ * GenericKnimeNodes is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.genericworkflownodes.knime.execution.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
+
+import org.knime.core.node.NodeLogger;
+
+import com.genericworkflownodes.knime.cliwrapper.CLIElement;
+import com.genericworkflownodes.knime.cliwrapper.CLIMapping;
+import com.genericworkflownodes.knime.config.INodeConfiguration;
+import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
+import com.genericworkflownodes.knime.execution.ICommandGenerator;
+import com.genericworkflownodes.knime.parameter.FileListParameter;
+import com.genericworkflownodes.knime.parameter.FileParameter;
+import com.genericworkflownodes.knime.parameter.ListParameter;
+import com.genericworkflownodes.knime.parameter.Parameter;
+import com.genericworkflownodes.knime.GenericNodesPlugin;
+/**
+ * Implements a Docker tool specific generation of a command line.
+ * 
+ * @author schubert
+ */
+public class DockerCommandGenerator extends CLICommandGenerator implements ICommandGenerator {
+
+    protected static final NodeLogger logger = NodeLogger
+            .getLogger(CLICommandGenerator.class);
+   
+    protected static final String DOCKER_COMMAND = "docker";
+    protected static final String DOCKER_EXECUTION = "run";
+    protected static final String DOCKER_MOUNT_COMMAND = "-v";
+    protected static final String DOCKER_INTERNAL_MOUNT = "/var/shared/";
+    protected static final String DOCKER_DIR_SEP = "/";
+    
+    //private INodeConfiguration nodeConfig;
+    private IPluginConfiguration pluginConfig;
+    
+    public List<String> generateCommands(INodeConfiguration nodeConfiguration,
+            IPluginConfiguration pluginConfiguration, File workingDirectory)
+            throws Exception {
+
+        // ease the passing around of variables
+        nodeConfig = nodeConfiguration;
+        pluginConfig = pluginConfiguration;
+               
+        // export the node configuration as plain text, for debugging and
+        // logging
+        exportPlainConfiguration(workingDirectory);
+
+        List<String> commands;
+
+        try {
+            commands = processCLI();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            nodeConfig = null;
+        }
+
+        return commands;
+    }
+    
+    
+    /**
+     * Converts the CLI part of the configuration to a list of commands that can
+     * be send to the shell.
+     * 
+     * @return A configured list of commands.
+     * @throws Exception
+     *             Is thrown if the configuration values are invalid.
+     */
+    protected List<String> processCLI() throws Exception {
+        List<String> commands = new ArrayList<String>();
+        List<String> dockerCommands = new ArrayList<String>();
+        Map<String, String> hostDockerMap = new HashMap<String, String>();
+        dockerCommands.add(GenericNodesPlugin.getDockerInstallationDir()
+                            +File.separator+DOCKER_COMMAND);
+        dockerCommands.add(DOCKER_EXECUTION);
+        commands.add(nodeConfig.getExecutablePath()+nodeConfig.getExecutableName());
+        for (CLIElement cliElement : nodeConfig.getCLI().getCLIElement()) {
+            logger.info("CLIElement: " + cliElement.getOptionIdentifier());
+
+            if (!"".equals(cliElement.getOptionIdentifier())
+                    && cliElement.getMapping().size() == 0) {
+                // simple fixed argument for the command line, no mapping to
+                // params given
+
+                // to avoid problems with spaces in commands we split fixed
+                // values
+                String[] splitResult = cliElement.getOptionIdentifier().split(
+                        " ");
+                for (String splittedCommand : splitResult) {
+                    commands.add(splittedCommand);
+                }
+            } else if (super.isMappedToBooleanParameter(cliElement)) {
+                // it is mapped to bool
+                super.handleBooleanParameter(commands, cliElement);
+                
+            } else {
+
+                List<List<String>> extractedParameterValues = extractParamterValues(cliElement, dockerCommands,hostDockerMap);
+                validateExtractedParameters(extractedParameterValues);
+
+                // we only add those parameters to the command line if they
+                // contain any values, this removes optional parameters if they
+                // were not set
+                if (extractedParameterValues.size() != 0) {
+                    expandParameters(extractedParameterValues, cliElement,
+                            commands);
+                }
+            }
+        }
+        try{
+            String dockerContainer = pluginConfig.getToolProperty(nodeConfig.getName()).getProperty("dockerImage", null);
+            dockerCommands.add(dockerContainer.replace("\"", ""));
+            dockerCommands.addAll(commands);
+            return dockerCommands;
+        }catch (NullPointerException e){
+            throw new Exception(String.format("Docker-Node %s has no image defined", nodeConfig.getName()));
+        }
+    }
+
+
+    private List<List<String>> extractParamterValues(CLIElement cliElement,
+            List<String> dockerCommands, Map<String, String> hostDockerMap) throws IOException {
+        
+        List<List<String>> extractedParameterValues = new ArrayList<List<String>>();
+        
+        for (CLIMapping cliMapping : cliElement.getMapping()) {
+            if (nodeConfig.getParameterKeys().contains(
+                    cliMapping.getReferenceName())) {
+
+                Parameter<?> p = nodeConfig.getParameter(cliMapping
+                        .getReferenceName());
+                if (!p.isNull()) {
+                    if (p instanceof ListParameter) {
+                        ListParameter lp = (ListParameter) p;
+                        if (lp.getStrings().size() > 0) {
+                            extractedParameterValues.add(lp.getStrings());
+                        }
+                    } else if (p instanceof FileParameter){
+                        extractedParameterValues.add(
+                                handleFileParameter( ((FileParameter) p).getValue(), 
+                                        dockerCommands, 
+                                        hostDockerMap) );
+                        
+                    } else if (p instanceof FileListParameter) {
+                        List<String> fl = ((FileListParameter) p).getValue();
+                        if (fl.size() > 0){
+                            for(String hostFile:fl){
+                                extractedParameterValues.add(
+                                        handleFileParameter(hostFile, 
+                                                dockerCommands, 
+                                                hostDockerMap)
+                                        );
+                            }
+                        }
+                    } else {
+                        List<String> l = new ArrayList<String>();
+                        l.add(p.getStringRep());
+                        extractedParameterValues.add(l);
+                    }
+                }
+            }
+        }
+        return extractedParameterValues;
+    }
+
+    /***
+     * 
+     * Process a file parameter by specifying the docker mount point and
+     * altering the file paths to fit the internal docker path
+     * 
+     * @param hostFile string to file on host system
+     * @param dockerCommands a list of specific docker commands
+     * @param hostDockerMap a map of host paths to docker paths that have already been mapped
+     * @return List of extracted commands
+     * @throws IOException
+     */
+    private List<String> handleFileParameter(String hostFile,
+            List<String> dockerCommands, Map<String, String> hostDockerMap) 
+            throws IOException {
+        
+        String dockerMount;
+        File fileParam = new File(hostFile);
+        String hostPath = toUnixPath(fileParam.getParentFile().getCanonicalPath());
+        
+        if ( hostDockerMap.containsKey(hostPath)){
+            dockerMount = hostDockerMap.get(hostPath);
+            
+        }else{
+             dockerMount = DOCKER_INTERNAL_MOUNT
+                    +dockerCommands.size()
+                    +DOCKER_DIR_SEP;
+             hostDockerMap.put(hostPath, dockerMount);
+             dockerCommands.add(DOCKER_MOUNT_COMMAND);
+             dockerCommands.add(hostPath+":"+dockerMount);
+        }  
+
+            
+        List<String> l = new ArrayList<String>();
+        l.add(dockerMount+fileParam.getName());
+        
+        return l;
+    }
+
+    /***
+     * Normalizes paths to unix basted paths
+     * 
+     * Note1: Docker 1.9 assumes path used for mounting
+     * are Unix-paths
+     * 
+     * Note2: For occurring problems see 
+     * https://github.com/docker/docker/issues/12590#issuecomment-96767796
+     * 
+     * @param hostFile
+     * @return
+     */
+    private String toUnixPath(final String hostFile) {
+       if(!hostFile.startsWith("/")){
+         String drive = hostFile.substring(0, 1);  
+         return "/"+hostFile.replace("\\", 
+                 "/").replace(":", "").replaceFirst(drive, 
+                         drive.toLowerCase());
+       }else{
+         return hostFile;
+       }
+    }
+    
+
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalDockerToolExecutor.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalDockerToolExecutor.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2016, benjamin Schubert.
+ *
+ * This file is part of GenericKnimeNodes.
+ * 
+ * GenericKnimeNodes is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.genericworkflownodes.knime.execution.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.io.File;
+
+import com.genericworkflownodes.knime.config.INodeConfiguration;
+import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
+import com.genericworkflownodes.knime.custom.config.NoBinaryAvailableException;
+import com.genericworkflownodes.knime.execution.IToolExecutor;
+import com.genericworkflownodes.knime.execution.ToolExecutionFailedException;
+import com.genericworkflownodes.knime.execution.impl.LocalToolExecutor.StreamGobbler;
+import com.genericworkflownodes.util.Helper;
+import com.genericworkflownodes.util.StringUtils;
+import com.genericworkflownodes.knime.GenericNodesPlugin;
+
+public class LocalDockerToolExecutor extends LocalToolExecutor implements IToolExecutor {
+    
+    private static final String DOCKER_CHECK = "docker-machine status ";
+    private static final String DOCKER_START = "docker-machine start ";
+    private static final String DOCKER_STOPPED = "Stopped";
+    private static final String DOCKER_SET_ENV_WIN = "__DOCKER_PATH__docker-machine env __DOCKER_VM__";
+    private static final String DOCKER_SET_ENV_MAC = "__DOCKER_PATH__docker-machine env __DOCKER_VM__";
+ 
+    @Override
+    public int execute() throws ToolExecutionFailedException {
+        try {
+            List<String> command = new ArrayList<String>();
+            command.addAll(m_commands);
+    
+            // emit command
+            LOGGER.debug("Executing: " + StringUtils.join(command, " "));
+    
+            // build process
+            ProcessBuilder builder = new ProcessBuilder(command);
+            setupProcessEnvironment(builder);
+    
+            if (m_workingDirectory != null) {
+                builder.directory(m_workingDirectory);
+            }
+    
+            // execute
+            m_process = builder.start();
+    
+            // prepare capture of cerr/cout streams
+            StreamGobbler stdOutGobbler = new StreamGobbler(
+                    m_process.getInputStream());
+            StreamGobbler stdErrGobbler = new StreamGobbler(
+                    m_process.getErrorStream());
+    
+            // start separate threads to capture the cerr/cout streams
+            stdErrGobbler.start();
+            stdOutGobbler.start();
+    
+            // fetch return code
+            m_returnCode = m_process.waitFor();
+    
+            // extract messages from stderr and stdout
+            m_stdOut = stdOutGobbler.getContent();
+            m_stdErr = stdErrGobbler.getContent();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to execute tool " + m_executable.getName(), e);
+            throw new ToolExecutionFailedException("Failed to execute tool "
+                    + m_executable.getName(), e);
+        }
+        return m_returnCode;    
+    }
+    
+    /**
+     * Initialization method of the executor.
+     * 
+     * @param nodeConfiguration
+     * @param pluginConfiguration
+     */
+    @Override
+    public void prepareExecution(INodeConfiguration nodeConfiguration,
+            IPluginConfiguration pluginConfiguration) throws Exception {
+        super.prepareExecution(nodeConfiguration, pluginConfiguration);
+        Map<String, String> env = super.getEnvironmentVariables();
+        if(env.containsKey("PATH")){
+            env.put("PATH", env.get("PATH")
+                    +File.pathSeparator+GenericNodesPlugin.getDockerInstallationDir()
+                    +File.pathSeparator+GenericNodesPlugin.getVmInstllationDir());  
+        }else{
+            env.put("PATH", GenericNodesPlugin.getDockerInstallationDir()
+                    +File.pathSeparator+GenericNodesPlugin.getVmInstllationDir());
+        }
+        activateDockerMachine(pluginConfiguration);
+    }
+    
+    /**
+     * Checks if a docker-machine has to be activated (only necessary on Mac and Windows machines), 
+     * if so which and 
+     * @throws ToolExecutionFailedException 
+     */
+    private void activateDockerMachine(IPluginConfiguration pluginConfiguration) 
+            throws ToolExecutionFailedException {
+        String dockerPath = GenericNodesPlugin.getDockerInstallationDir()+File.separator;
+        if(Helper.isMac()|| Helper.isWin()){
+            if(executeDockerCommand(dockerPath+DOCKER_CHECK+pluginConfiguration.getDockerMachine()).equals(DOCKER_STOPPED)){
+                executeDockerCommand(dockerPath+DOCKER_START+pluginConfiguration.getDockerMachine());
+                }
+            if(Helper.isMac()){
+                setDockerMacEnv(executeDockerCommand(DOCKER_SET_ENV_MAC.replace("__DOCKER_VM__", 
+                        pluginConfiguration.getDockerMachine()).replace("__DOCKER_PATH__", 
+                                dockerPath)));
+            }else{
+                setDockerWinEnv(executeDockerCommand(DOCKER_SET_ENV_WIN.replace("__DOCKER_VM__", 
+                        pluginConfiguration.getDockerMachine()).replace("__DOCKER_PATH__",
+                                dockerPath)));
+            }
+        }
+        
+    }
+
+    /**
+     * Parses the output of docker-machine env __DOCKER_VM___ 
+     * and adds the environmental variables to the env-dicktionary
+     * works only for cmd.exe not for powershell
+     * @param executeDockerCommand
+     */
+    //TODO: generalize to other windows supported shells
+     private void setDockerWinEnv(final String executeDockerCommand) {
+        Map<String, String> env = super.getEnvironmentVariables();
+        for(String line: executeDockerCommand.split(System.getProperty("line.separator"))){
+            if(line.startsWith("SET")){
+                String[] envCommand = line.split("\\s+"); 
+                String[] tmp = envCommand[1].split("=");
+                env.put(tmp[0],tmp[1].replace("\"", ""));
+            }
+        }
+    }
+
+    /**
+      * Parses the output of docker-machine env __DOCKER_VM___ 
+      * and adds the environmental variables to the env-dicktionary
+      * @param executeDockerCommand
+      */
+    private void setDockerMacEnv(final String dockerEnvOutput) {
+        Map<String, String> env = super.getEnvironmentVariables();
+        for(String line: dockerEnvOutput.split(System.getProperty("line.separator"))){
+            if(!line.startsWith("#")){
+               //TODO: generalize this to all supported shells
+               String[] envCommand = line.split("\\s+"); 
+               String[] tmp = envCommand[1].split("=");
+               //this should work under bash
+               env.put(tmp[0],tmp[1].replace("\"", ""));
+             }
+         }
+
+        
+    }
+
+    /**
+     * Execute docker-machine specific commands and return STDOUT as string
+     * @param command docker-machine command
+     * @param env environmental variables needed to execute docker-machine
+     * @return STDOUT
+     * @throws ToolExecutionFailedException
+     */
+    private String executeDockerCommand(String command) 
+            throws ToolExecutionFailedException {
+        try{
+            final ProcessBuilder pb = new ProcessBuilder(command.split("\\s+"));
+            super.setupProcessEnvironment(pb);
+            final Process p = pb.start();
+
+            // prepare capture of cerr/cout streams
+            StreamGobbler stdOutGobbler = new StreamGobbler(
+                            p.getInputStream());
+            StreamGobbler stdErrGobbler = new StreamGobbler(
+                            p.getErrorStream());
+    
+            // start separate threads to capture the cerr/cout streams
+            stdErrGobbler.start();
+            stdOutGobbler.start();
+    
+            // fetch return code
+            int returnCode = p.waitFor();
+    
+            // extract messages from stderr and stdout
+            LinkedList<String> stdOut = stdOutGobbler.getContent();
+            LinkedList<String> stdErr = stdErrGobbler.getContent();
+            
+            if(returnCode != 0){
+                StringBuilder builder = new StringBuilder();
+                for(String s: stdErr){
+                    builder.append(s+ System.getProperty("line.separator"));
+                }
+                LOGGER.warn("Failed to execute tool " + getExecutable().getName()+" "+builder.toString(), null);
+                throw new ToolExecutionFailedException("Failed to execute tool "
+                            + getExecutable().getName()+" "+builder.toString(), null);
+            }
+            
+            StringBuilder builder = new StringBuilder();
+            for(String s: stdOut){
+                builder.append(s+ System.getProperty("line.separator"));
+            }
+            return builder.toString().trim();
+            
+        } catch (Exception e) {
+            LOGGER.warn("Failed to execute tool " + getExecutable().getName(), e);
+            throw new ToolExecutionFailedException("Failed to execute tool "
+                        + getExecutable().getName(), e);
+        }
+    }
+    
+    @Override
+    protected void findExecutable(INodeConfiguration nodeConfiguration,
+            IPluginConfiguration pluginConfiguration)
+            throws NoBinaryAvailableException {
+    }
+    
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalToolExecutor.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalToolExecutor.java
@@ -62,7 +62,7 @@ public class LocalToolExecutor implements IToolExecutor {
      * 
      * @author aiche
      */
-    private static class StreamGobbler extends Thread {
+    protected static class StreamGobbler extends Thread {
         /**
          * The stream that is gobbled.
          */
@@ -120,38 +120,45 @@ public class LocalToolExecutor implements IToolExecutor {
     /**
      * The working directory where the process will be executed.
      */
-    private File m_workingDirectory;
+    protected File m_workingDirectory;
 
     /**
      * The environment variables that will be passed to the running environment.
      */
-    private final Map<String, String> m_environmentVariables;
+    protected final Map<String, String> m_environmentVariables;
 
     /**
      * The return code of the process.
      */
-    private int m_returnCode;
+    protected int m_returnCode;
 
     /**
      * The std-out of the executed process.
      */
-    private LinkedList<String> m_stdOut;
+    protected LinkedList<String> m_stdOut;
 
     /**
      * The std-err of the executed process.
      */
-    private LinkedList<String> m_stdErr;
+    protected LinkedList<String> m_stdErr;
 
-    private Process m_process;
+    protected Process m_process;
 
-    private ICommandGenerator m_generator;
+    protected ICommandGenerator m_generator;
 
     /**
      * The executable.
      */
-    private File m_executable;
+    protected File m_executable;
 
-    private List<String> m_commands;
+    protected List<String> m_commands;
+
+    /**
+     * @return the m_environmentVariables
+     */
+    public Map<String, String> getEnvironmentVariables() {
+        return m_environmentVariables;
+    }
 
     /**
      * C'tor.
@@ -331,11 +338,16 @@ public class LocalToolExecutor implements IToolExecutor {
      * @param builder
      *            The builder that should be initialized.
      */
-    private void setupProcessEnvironment(ProcessBuilder builder) {
+    protected void setupProcessEnvironment(ProcessBuilder builder) {
         for (String key : m_environmentVariables.keySet()) {
             String value = expandEnvironmentVariables(m_environmentVariables
                     .get(key));
-            builder.environment().put(key, value);
+            if(builder.environment().containsKey(key)){
+                builder.environment().put(key, value
+                        +File.pathSeparator+builder.environment().get(key));
+            }else{
+                builder.environment().put(key, value);
+            }
         }
     }
 
@@ -363,7 +375,7 @@ public class LocalToolExecutor implements IToolExecutor {
      * @throws NoBinaryAvailableException
      *             If no matching binary was found.
      */
-    private void findExecutable(INodeConfiguration nodeConfiguration,
+    protected void findExecutable(INodeConfiguration nodeConfiguration,
             IPluginConfiguration pluginConfiguration)
             throws NoBinaryAvailableException {
         m_executable = pluginConfiguration.getBinaryManager().findBinary(
@@ -378,5 +390,9 @@ public class LocalToolExecutor implements IToolExecutor {
     @Override
     public LinkedList<String> getToolErrorOutput() {
         return m_stdErr;
+    }
+    
+    public File getExecutable(){
+        return m_executable; 
     }
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -42,6 +42,7 @@ import org.knime.core.node.NodeSettingsWO;
 import org.knime.core.node.port.PortObject;
 import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
+import org.knime.core.node.port.PortTypeRegistry;
 
 import com.genericworkflownodes.knime.GenericNodesPlugin;
 import com.genericworkflownodes.knime.base.data.port.FileStorePrefixURIPortObject;
@@ -87,8 +88,8 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
     /**
      * Short-cut for optional ports.
      */
-    public static final PortType OPTIONAL_PORT_TYPE = new PortType(
-            IURIPortObject.class, true);
+    public static final PortType OPTIONAL_PORT_TYPE = PortTypeRegistry.getInstance().getPortType(IURIPortObject.class, true);
+
 
     /**
      * Contains information on which of the available output types is selected
@@ -429,7 +430,7 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         return createOutSpec();
     }
 
-    private void checkIfToolExists() throws InvalidSettingsException {
+    protected void checkIfToolExists() throws InvalidSettingsException {
         try {
             m_pluginConfig.getBinaryManager().findBinary(
                     m_nodeConfig.getExecutableName());

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/DockerMachinePreferencePage.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/DockerMachinePreferencePage.java
@@ -1,0 +1,105 @@
+package com.genericworkflownodes.knime.preferences;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.DirectoryFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+import com.genericworkflownodes.knime.GenericNodesPlugin;
+
+public class DockerMachinePreferencePage extends FieldEditorPreferencePage
+        implements IWorkbenchPreferencePage {
+
+    /**
+     * The {@link DirectoryFieldEditor} to select the installation directory for
+     * the Docker-Machine command.
+     */
+    private DirectoryFieldEditor dockerMachineInstallDir;
+
+    /**
+     * The {@link DirectoryFieldEditor} to select the installation directory for
+     * the underlying VM driver commands used by 'docker-machine'.
+     */
+    private DirectoryFieldEditor vmDriverInstallDir;
+
+    /**
+     * The {@link BiikeanFieldEditor} to specify whether $HOME should be used as 
+     * TMP directory, which is needed on Mac and Windows to mount directories into
+     * Docker container
+     */
+    private BooleanFieldEditor homeTMPFieldEditor;
+    
+    public DockerMachinePreferencePage() {
+        super(GRID);
+        IPreferenceStore store = GenericNodesPlugin.getDefault()
+                .getPreferenceStore();
+        setPreferenceStore(store);
+        setDescription("Docker Perfernece Page"); //$NON-NLS-1$
+    }
+    
+    
+    @Override
+    public void init(IWorkbench workbench) {
+        IPreferenceStore store = GenericNodesPlugin.getDefault()
+                .getPreferenceStore();
+        GenericNodesPlugin.setDockerInstallationDir(
+                store.getString(PreferenceInitializer.DOCKER_MACHINE_INSTALLATION_DIRECTORY));
+        GenericNodesPlugin.setVmInstllationDir(
+                store.getString(PreferenceInitializer.VM_INSTALLATION_DIRECTORY));
+    }
+
+    @Override
+    protected void createFieldEditors() {
+        // installation directory for docker-machine
+        dockerMachineInstallDir = new DirectoryFieldEditor(
+                PreferenceInitializer.DOCKER_MACHINE_INSTALLATION_DIRECTORY,
+                "Docker Instllation Directory", //$NON-NLS-1$
+                getFieldEditorParent());
+        addField(this.dockerMachineInstallDir);
+        dockerMachineInstallDir.setPreferenceStore(getPreferenceStore());
+        // allow empty value if docker-machine is not installed
+        dockerMachineInstallDir.setEmptyStringAllowed(true);
+        dockerMachineInstallDir
+                .setValidateStrategy(StringFieldEditor.VALIDATE_ON_KEY_STROKE);
+        dockerMachineInstallDir.setPage(this);
+        dockerMachineInstallDir.setErrorMessage(
+                "Invalid Docker-Machine installation directory."); //$NON-NLS-1$
+        dockerMachineInstallDir.showErrorMessage();
+        dockerMachineInstallDir.load();
+        
+        vmDriverInstallDir = new DirectoryFieldEditor(
+                PreferenceInitializer.VM_INSTALLATION_DIRECTORY,
+                "Vm Installation Directory of Docker-Machine", //$NON-NLS-1$
+                getFieldEditorParent());
+        addField(vmDriverInstallDir);
+        vmDriverInstallDir.setPreferenceStore(getPreferenceStore());
+        // allow empty value if docker-machine is not installed
+        vmDriverInstallDir.setPage(this);
+        vmDriverInstallDir.setEmptyStringAllowed(true);
+        vmDriverInstallDir.setErrorMessage(
+                "Invalid VM installation directory."); //$NON-NLS-1$
+        vmDriverInstallDir.showErrorMessage();
+        vmDriverInstallDir
+                .setValidateStrategy(StringFieldEditor.VALIDATE_ON_KEY_STROKE);
+        vmDriverInstallDir.load();
+
+    }
+
+    
+    @Override
+    public boolean performOk() {
+        IPreferenceStore store = GenericNodesPlugin.getDefault()
+                .getPreferenceStore();
+        String  dockerInstallDir = dockerMachineInstallDir.getStringValue();
+        String vmInstallDir = vmDriverInstallDir.getStringValue();
+        store.setValue(PreferenceInitializer.DOCKER_MACHINE_INSTALLATION_DIRECTORY, dockerInstallDir);
+        store.setValue(PreferenceInitializer.VM_INSTALLATION_DIRECTORY, vmInstallDir);
+
+        GenericNodesPlugin.setDockerInstallationDir(dockerInstallDir);
+        GenericNodesPlugin.setVmInstllationDir(vmInstallDir);
+        return true;
+    }
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/PreferenceInitializer.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/PreferenceInitializer.java
@@ -22,7 +22,7 @@ import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import com.genericworkflownodes.knime.GenericNodesPlugin;
-
+import com.genericworkflownodes.util.Helper;
 /**
  * Initializer for the GKN preferences.
  * 
@@ -38,7 +38,17 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
      * Preferences key for the debug mode flag.
      */
     public static final String PREF_DEBUG_MODE = "knime.gkn.debug";
-
+    
+    /**
+     * Preferences key for the Docker-Machine installation directory.
+     */
+    public static final String DOCKER_MACHINE_INSTALLATION_DIRECTORY = "knime.gkn.dockerMachineInstallationDir";
+    
+    /**
+     * Preferences key for the VM installation directory.
+     */
+    public static final String VM_INSTALLATION_DIRECTORY = "knime.gkn.vmInstallationDir";
+    
     @Override
     public void initializeDefaultPreferences() {
         // get the preference store for the UI plugin
@@ -47,6 +57,11 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
         // set default values
         store.setDefault(PREF_DEBUG_MODE, GenericNodesPlugin.isDebug());
-    }
 
+        store.setDefault(DOCKER_MACHINE_INSTALLATION_DIRECTORY,
+                    GenericNodesPlugin.getDockerInstallationDir()); //$NON-NLS-1$
+        store.setDefault(VM_INSTALLATION_DIRECTORY,
+                    GenericNodesPlugin.getVmInstllationDir()); //$NON-NLS-1$
+
+    }
 }


### PR DESCRIPTION
# GKN Docker Extension

This extension allows GKN to call command line tools wrapped in a Docker image (www.docker.com). For doing so we have implemented two classes: 
- **DockerCommandGenerator**: It takes the usual CTD file and adds the docker specific parts to the command line call.  It collects input and output ports and defines mount points within the docker image and bends the file paths to fit the internal mount points accordingly.
- **LocalDockerToolExecutor**: It starts the docker daemon if necessary and sets the docker specific environmental variables before calling the generated command.

We additionally extended the **_plugin.property**_ syntax to allow tool-specific configurations. In particular we use the syntax to specify the docker image to use for each tool and the docker daemon. Syntax is as follows:

dockerMachine=<docker-daemon> (if non declared **_default**_ is used)
tool.<tool-name>.<configFlag>=<value>

**_Example:**_
tool.BLAST.dockerImage=blast:v1, (blast:v1 is a docker image containing BLAST).

We also implemented a Docker-specific **_preference page**_, at which the user can specify the installation path of the docker machine and VM-ware (for Windows and Mac OS X user) if they differ from the default installation directories.
## Usage:

The only thing that has to be modified is the **_plugin.property**_ file. The fields **_executor**_ and **_commandGenerator**_ have to be changed to **_LocalDockerToolExecutor**_ and **_DockerCommandGenerator**_ respectively. And one has to specify the Docker image to load for each tool with the described tool-specific tag. The CTD remains unchanged.
## Restrictions:
- Since Docker runs with a VirtualBox on Windows and Mac OS X, the temporary file directory has to reside in the **_user directory**_. Otherwise Docker is unable to mount the input files. This is done by default for Windows, but on Mac OS X machines the user has to manually changed the TMP directory within KNIME.
- Under Linux the docker daemon has to be started by the user since root privileges are needed.
## Tested on:

Tested on Mac OS X 10.11.1, Windows 8.1, Linux Ubuntu 14.04 LTS with Docker >= 1.9 and KNIME SDK >= 3.0
