### PR TITLE
[INTERNAL] updated to native mac and windows docker implelemtation

### DIFF
--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/GenericNodesPlugin.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/GenericNodesPlugin.java
@@ -56,6 +56,11 @@ public class GenericNodesPlugin extends AbstractUIPlugin {
      * The VM installation directory used by docker-machine
      */
     private static String vmInstllationDir = "";
+
+    /**
+     * State of Docker-Toolbox usage
+     */
+    private static Boolean isDockerToolBoxEnabled = false;
     
     /**
      * Check if the plug-in is in isDebugModeEnabled mode.
@@ -66,6 +71,16 @@ public class GenericNodesPlugin extends AbstractUIPlugin {
         return GenericNodesPlugin.isDebugModeEnabled;
     }
 
+    /**
+     * Checks if Docker-Toolbox should be used instead of native 
+     * Docker implementation
+     * 
+     * @return True if Docker-Toolbox should be used, false otherwise
+     */
+    public static boolean isDockerToolBox() {
+        return GenericNodesPlugin.isDockerToolBoxEnabled;
+    }
+    
     /**
      * Sets the isDebugModeEnabled status of the plug-in.
      * 
@@ -152,5 +167,10 @@ public class GenericNodesPlugin extends AbstractUIPlugin {
     public static void setVmInstllationDir(String vmInstllationDir) {
         LOGGER.debug("Setting GKN vmInstllationDir: " + vmInstllationDir);
         GenericNodesPlugin.vmInstllationDir = vmInstllationDir;
+    }
+
+    public static void setDockerToolBoxUsage(Boolean dockerToolboxUsage) {
+        LOGGER.debug("Setting GKN Docker-Toolbox usage: " + String.valueOf(dockerToolboxUsage));
+        GenericNodesPlugin.isDockerToolBoxEnabled  = dockerToolboxUsage;
     }
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalDockerToolExecutor.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalDockerToolExecutor.java
@@ -116,7 +116,7 @@ public class LocalDockerToolExecutor extends LocalToolExecutor implements IToolE
     private void activateDockerMachine(IPluginConfiguration pluginConfiguration) 
             throws ToolExecutionFailedException {
         String dockerPath = GenericNodesPlugin.getDockerInstallationDir()+File.separator;
-        if(Helper.isMac()|| Helper.isWin()){
+        if((Helper.isMac()|| Helper.isWin()) && GenericNodesPlugin.isDockerToolBox()){
             if(executeDockerCommand(dockerPath+DOCKER_CHECK+pluginConfiguration.getDockerMachine()).equals(DOCKER_STOPPED)){
                 executeDockerCommand(dockerPath+DOCKER_START+pluginConfiguration.getDockerMachine());
                 }
@@ -180,11 +180,13 @@ public class LocalDockerToolExecutor extends LocalToolExecutor implements IToolE
      */
     private String executeDockerCommand(String command) 
             throws ToolExecutionFailedException {
+        
+        String name = (getExecutable() == null) ? "docker-machine default" : getExecutable().getName();
         try{
             final ProcessBuilder pb = new ProcessBuilder(command.split("\\s+"));
             super.setupProcessEnvironment(pb);
             final Process p = pb.start();
-
+            
             // prepare capture of cerr/cout streams
             StreamGobbler stdOutGobbler = new StreamGobbler(
                             p.getInputStream());
@@ -207,9 +209,9 @@ public class LocalDockerToolExecutor extends LocalToolExecutor implements IToolE
                 for(String s: stdErr){
                     builder.append(s+ System.getProperty("line.separator"));
                 }
-                LOGGER.warn("Failed to execute tool " + getExecutable().getName()+" "+builder.toString(), null);
+                LOGGER.warn("Failed to execute tool " + name +" "+builder.toString(), null);
                 throw new ToolExecutionFailedException("Failed to execute tool "
-                            + getExecutable().getName()+" "+builder.toString(), null);
+                            + name +" "+builder.toString(), null);
             }
             
             StringBuilder builder = new StringBuilder();
@@ -219,9 +221,9 @@ public class LocalDockerToolExecutor extends LocalToolExecutor implements IToolE
             return builder.toString().trim();
             
         } catch (Exception e) {
-            LOGGER.warn("Failed to execute tool " + getExecutable().getName(), e);
+            LOGGER.warn("Failed to execute tool " + name, e);
             throw new ToolExecutionFailedException("Failed to execute tool "
-                        + getExecutable().getName(), e);
+                        + name, e);
         }
     }
     

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/DockerMachinePreferencePage.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/DockerMachinePreferencePage.java
@@ -31,6 +31,15 @@ public class DockerMachinePreferencePage extends FieldEditorPreferencePage
      * Docker container
      */
     private BooleanFieldEditor homeTMPFieldEditor;
+
+    /**
+     * The {@link BiikeanFieldEditor} to specify whether Docker Toolbox is used as 
+     * instead of the native Docker implementations, which requires a docker-machine
+     * is constantly running.
+     * Docker container
+     */
+    private BooleanFieldEditor dockerToolBoxFieldEditor;
+    
     
     public DockerMachinePreferencePage() {
         super(GRID);
@@ -49,6 +58,8 @@ public class DockerMachinePreferencePage extends FieldEditorPreferencePage
                 store.getString(PreferenceInitializer.DOCKER_MACHINE_INSTALLATION_DIRECTORY));
         GenericNodesPlugin.setVmInstllationDir(
                 store.getString(PreferenceInitializer.VM_INSTALLATION_DIRECTORY));
+        GenericNodesPlugin.setDockerToolBoxUsage(
+                store.getBoolean(PreferenceInitializer.VM_INSTALLATION_DIRECTORY));
     }
 
     @Override
@@ -86,6 +97,10 @@ public class DockerMachinePreferencePage extends FieldEditorPreferencePage
                 .setValidateStrategy(StringFieldEditor.VALIDATE_ON_KEY_STROKE);
         vmDriverInstallDir.load();
 
+        dockerToolBoxFieldEditor = new BooleanFieldEditor(
+                PreferenceInitializer.DOCKER_MACHINE_USAGE, 
+                "Docker-Toolbox usage", getFieldEditorParent());
+        addField(dockerToolBoxFieldEditor);
     }
 
     
@@ -95,9 +110,12 @@ public class DockerMachinePreferencePage extends FieldEditorPreferencePage
                 .getPreferenceStore();
         String  dockerInstallDir = dockerMachineInstallDir.getStringValue();
         String vmInstallDir = vmDriverInstallDir.getStringValue();
+        boolean flag = dockerToolBoxFieldEditor.getBooleanValue();
         store.setValue(PreferenceInitializer.DOCKER_MACHINE_INSTALLATION_DIRECTORY, dockerInstallDir);
         store.setValue(PreferenceInitializer.VM_INSTALLATION_DIRECTORY, vmInstallDir);
-
+        store.setValue(PreferenceInitializer.DOCKER_MACHINE_USAGE, flag);
+        
+        GenericNodesPlugin.setDockerToolBoxUsage(flag);
         GenericNodesPlugin.setDockerInstallationDir(dockerInstallDir);
         GenericNodesPlugin.setVmInstllationDir(vmInstallDir);
         return true;

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/PreferenceInitializer.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/PreferenceInitializer.java
@@ -45,6 +45,11 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
     public static final String DOCKER_MACHINE_INSTALLATION_DIRECTORY = "knime.gkn.dockerMachineInstallationDir";
     
     /**
+     * Preferences key for the Docker-Machine usage.
+     */
+    public static final String DOCKER_MACHINE_USAGE = "knime.gkn.dockerMachineUsage";
+    
+    /**
      * Preferences key for the VM installation directory.
      */
     public static final String VM_INSTALLATION_DIRECTORY = "knime.gkn.vmInstallationDir";
@@ -57,11 +62,13 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
         // set default values
         store.setDefault(PREF_DEBUG_MODE, GenericNodesPlugin.isDebug());
-
+        store.setDefault(DOCKER_MACHINE_USAGE, GenericNodesPlugin.isDebug());
+        
         store.setDefault(DOCKER_MACHINE_INSTALLATION_DIRECTORY,
                     GenericNodesPlugin.getDockerInstallationDir()); //$NON-NLS-1$
         store.setDefault(VM_INSTALLATION_DIRECTORY,
                     GenericNodesPlugin.getVmInstllationDir()); //$NON-NLS-1$
+
 
     }
 }


### PR DESCRIPTION
internal changes to be compatible with the new native docker implementations of mac and windows while still maintaining backwards compatibility (i.e. Docker-Toolbox).
