### PR TITLE
Reading of default values for Files

### DIFF
--- a/com.genericworkflownodes.knime.config.testing/test/com/genericworkflownodes/knime/config/reader/CTDConfigurationReaderTest.java
+++ b/com.genericworkflownodes.knime.config.testing/test/com/genericworkflownodes/knime/config/reader/CTDConfigurationReaderTest.java
@@ -73,7 +73,7 @@ public class CTDConfigurationReaderTest {
 
         FileParameter fp = (FileParameter) config
                 .getParameter("FileFilter.1.in");
-        assertNull(fp.getValue());
+        assertEquals("temp", fp.getValue());
 
         // get list restrictions
         assertNotNull(config.getParameter("FileFilter.1.peak_options.level"));

--- a/com.genericworkflownodes.knime.config.testing/test/com/genericworkflownodes/knime/config/writer/CTDConfigurationWriterTest.java
+++ b/com.genericworkflownodes.knime.config.testing/test/com/genericworkflownodes/knime/config/writer/CTDConfigurationWriterTest.java
@@ -98,7 +98,8 @@ public class CTDConfigurationWriterTest {
         assertEquals(false, no_progress.getValue());
         assertEquals(true, no_progress.isAdvanced());
 
-        assertEquals(3, config.getInputPorts().size());
+        // Three inputs, one required, one optional with default, one optional without default
+        assertEquals(2, config.getInputPorts().size());
         assertEquals("FileFilter.1.in", config.getInputPorts().get(0).getName());
     }
 }

--- a/com.genericworkflownodes.knime.config.testing/test/com/genericworkflownodes/knime/test/data/FileFilter.ctd
+++ b/com.genericworkflownodes.knime.config.testing/test/com/genericworkflownodes/knime/test/data/FileFilter.ctd
@@ -6,7 +6,7 @@
   <NODE name="FileFilter" description="Extracts or manipulates portions of data from peak, feature or consensus-feature files.">
     <ITEM name="version" value="1.11.0" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;FileFilter&apos;">
-      <ITEM name="in" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML,*.featureXML,*.consensusXML" />
+      <ITEM name="in" value="temp" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML,*.featureXML,*.consensusXML" />
       <ITEM name="in_type" value="" type="string" description="input file type -- default: determined from file extension or content#br#" required="false" advanced="false" restrictions="mzML,featureXML,consensusXML" />
       <ITEM name="out" value="" type="output-file" description="output file" required="true" advanced="false" supported_formats="*.mzML,*.featureXML,*.consensusXML" />
       <ITEM name="out_type" value="" type="string" description="output file type -- default: determined from file extension or content#br#" required="false" advanced="false" restrictions="mzML,featureXML,consensusXML" />
@@ -56,7 +56,7 @@
         <ITEM name="map_and" value="false" type="string" description="Consensus features are kept only if they contain exactly one feature from each map (as given above in &apos;map&apos;)." required="false" advanced="false" restrictions="true,false" />
         <NODE name="blackorwhitelist" description="Black or white listing of of MS2 spectra by consensus features.">
           <ITEM name="blacklist" value="true" type="string" description="True: remove matched MS2. False: retain matched MS2 spectra. Other levels are kept." required="false" advanced="false" restrictions="false,true" />
-          <ITEM name="file" value="" type="input-file" description="Input file containing consensus features whose corresponding MS2 spectra should be removed from the mzML file!#br#Matching tolerances are taken from &apos;consensus:blackorwhitelist:rt&apos; and &apos;consensus:blackorwhitelist:mz&apos; options.#br#If consensus:blackorwhitelist:maps is specified, only these will be used.#br#" required="false" advanced="false" supported_formats="*.consensusXML" />
+          <ITEM name="file" value="tempoptional" type="input-file" description="Input file containing consensus features whose corresponding MS2 spectra should be removed from the mzML file!#br#Matching tolerances are taken from &apos;consensus:blackorwhitelist:rt&apos; and &apos;consensus:blackorwhitelist:mz&apos; options.#br#If consensus:blackorwhitelist:maps is specified, only these will be used.#br#" required="false" advanced="false" supported_formats="*.consensusXML" />
           <ITEMLIST name="maps" type="int" description="maps used for black/white list filtering." required="false" advanced="false">
           </ITEMLIST>
           <ITEM name="rt" value="60" type="double" description="retention tolerance [s] for precursor to consensus feature position" required="false" advanced="false" restrictions="0:" />

--- a/com.genericworkflownodes.knime.config/src/com/genericworkflownodes/knime/config/reader/handler/ParamHandler.java
+++ b/com.genericworkflownodes.knime.config/src/com/genericworkflownodes/knime/config/reader/handler/ParamHandler.java
@@ -376,12 +376,15 @@ public class ParamHandler extends DefaultHandler {
                     .getDescription());
             ((FileListParameter) m_currentParameter).setIsOptional(p
                     .isOptional());
+            // Values will be filled at the end of the ITEMLIST tag.
         } else {
             m_currentParameter = new FileParameter(paramName, "");
             ((FileParameter) m_currentParameter).setPort(p);
             ((FileParameter) m_currentParameter).setDescription(p
                     .getDescription());
             ((FileParameter) m_currentParameter).setIsOptional(p.isOptional());
+            // Fills parameter with default value
+            ((FileParameter) m_currentParameter).setValue(attributes.getValue(ATTR_VALUE));
         }
 
         String attr_type = attributes.getValue(ATTR_TYPE);

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -775,29 +775,35 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
             throws Exception {
         // Transfer settings from the input ports into the configuration object
         for (int i = 0; i < inData.length; i++) {
-            // skip optional and unconnected inport ports
-            if (inData[i] == null) {
-                continue;
-            }
-
             // find the internal port for this PortObject
             Port port = m_nodeConfig.getInputPorts().get(i);
 
             IURIPortObject po = (IURIPortObject) inData[i];
-            List<URIContent> uris = po.getURIContents();
+            
 
             String name = port.getName();
+            // find the associated parameter in the configuration
+            Parameter<?> p = m_nodeConfig.getParameter(name);
+            
             boolean isMultiFile = port.isMultiFile();
             boolean isPrefix = port.isPrefix();
+            
+            // skip optional and unconnected inport ports
+            if (inData[i] == null) {
+                ((FileParameter) p).setValue(null);
+                continue;
+            }
+            
+            // connected: check contents
+            List<URIContent> uris = po.getURIContents();
 
+            // check validity of subtypes with actual inputs
             if (uris.size() > 1 && (!isMultiFile && !isPrefix)) {
                 throw new Exception(
                         "IURIPortObject with multiple URIs supplied at single URI port #"
                                 + i);
             }
 
-            // find the associated parameter in the configuration
-            Parameter<?> p = m_nodeConfig.getParameter(name);
             // check that we are actually referencing a file parameter from this
             // port
             if (!(p instanceof IFileParameter)) {


### PR DESCRIPTION
I came across this while fixing tests that crashed after omitting unconnected/empty ports.
It seems to me as if default values for File parameters in a CTD were not read. I see that it might not be necessary since they are overwritten during validation of the node with the actual connected URI(s). I don't know why this was done (no documentation) and it seems weird because from what I saw for FileLists, it is the case that defaults are read.
I think it is not wrong to actually read the defaults and I can not imagine a case that makes the nodes break, since these defaults will be overwritten anyway, when the node is configured. I made a change that resets the value of the according Fileparameters to null, when the inputs are null, so unconnected ports are also handled correctly.
IMHO this is a more intuitive behaviour and better makes sure that the connections in the GUI are reflected. But I am not sure, and I don't know if I missed a corner case.
@chahuistle @aiche Can you quickly think about the effects this might have?
