### PR TITLE
[FIX] FileMerger now also accepts lists of URIs

### DIFF
--- a/com.genericworkflownodes.knime/plugin.xml
+++ b/com.genericworkflownodes.knime/plugin.xml
@@ -29,14 +29,8 @@
     <node category-path="/community/GenericKnimeNodes/Flow" factory-class="com.genericworkflownodes.knime.nodes.flow.listzip.ListZipLoopEndNodeFactory" id="org.ballproject.knime.base.flow.listzip.ListZipLoopEndNodeFactory"/>
    	<node category-path="/community/GenericKnimeNodes/Flow" factory-class="com.genericworkflownodes.knime.nodes.flow.merger.FileMergerNodeFactory" id="com.genericworkflownodes.knime.nodes.merger.FileMergerNodeFactory"/>
 	<node category-path="/community/GenericKnimeNodes/Flow" factory-class="com.genericworkflownodes.knime.nodes.flow.image2file.Image2FilePortNodeFactory" id="com.genericworkflownodes.knime.nodes.io.image2file.Image2FilePortNodeFactory"/>
- <node
-       after="com.genericworkflownodes.knime.nodes.merger.FileMergerNodeFactory"
-       category-path="/community/GenericKnimeNodes/Flow"
-       deprecated="false"
-       factory-class="com.genericworkflownodes.knime.nodes.flow.splitter.FileSplitterNodeFactory"
-       id="com.genericworkflownodes.knime.nodes.flow.splitter.FileSplitterNodeFactory">
- </node>
-</extension>
+    <node category-path="/community/GenericKnimeNodes/Flow" factory-class="com.genericworkflownodes.knime.nodes.flow.splitter.FileSplitterNodeFactory" id="com.genericworkflownodes.knime.nodes.flow.splitter.FileSplitterNodeFactory"/>
+   </extension>
    
    <extension point="org.knime.product.splashExtension">
         <splashExtension icon="icons/GKN.png" id="com.genericworkflownodes.knime.splashExtension"/>

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/base/data/port/FileStoreReferenceURIPortObject.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/base/data/port/FileStoreReferenceURIPortObject.java
@@ -113,24 +113,34 @@ public class FileStoreReferenceURIPortObject extends FileStorePortObject
     public static FileStoreReferenceURIPortObject create(
             List<IURIPortObject> uriPortObjects) {
 
-        List<URIContent> uriContents = new ArrayList<URIContent>(
-                uriPortObjects.size());
-        List<String> relPaths = new ArrayList<String>(uriPortObjects.size());
-        List<Integer> fsIndices = new ArrayList<Integer>(uriPortObjects.size());
-        List<FileStore> fileStores = new ArrayList<FileStore>(
-                uriPortObjects.size());
+        List<URIContent> uriContents = new ArrayList<URIContent>();
+        List<String> relPaths = new ArrayList<String>();
+        List<Integer> fsIndices = new ArrayList<Integer>();
+        List<FileStore> fileStores = new ArrayList<FileStore>();
 
         for (IURIPortObject po : uriPortObjects) {
-            uriContents.add(po.getURIContents().get(0));
-            if (po instanceof AbstractFileStoreURIPortObject) {
-                AbstractFileStoreURIPortObject afspo = (AbstractFileStoreURIPortObject) po;
-                relPaths.add(afspo.getRelativePaths().get(0));
-                fileStores.add(afspo.getInternalFileStore());
-                fsIndices.add(fileStores.size() - 1);
-            } else {
-                // we add a dummy relative path
-                relPaths.add("");
-                fsIndices.add(-1);
+            int count = 0;
+            for (URIContent uriContent : po.getURIContents()) {
+                uriContents.add(uriContent);
+                if (po instanceof AbstractFileStoreURIPortObject) {
+                    AbstractFileStoreURIPortObject afspo = (AbstractFileStoreURIPortObject) po;
+                    relPaths.add(afspo.getRelativePaths().get(count));
+                    fileStores.add(afspo.getInternalFileStore());
+                    fsIndices.add(fileStores.size() - 1);
+                } else if (po instanceof FileStoreReferenceURIPortObject) {
+                    FileStoreReferenceURIPortObject frpo = (FileStoreReferenceURIPortObject) po;
+                    relPaths.add(frpo.getRelativePath(count));
+                    if (count < frpo.getFileStoreCount()) {
+                        fileStores.add(frpo.getFileStore(count));
+                    }
+                    fsIndices.add(frpo.getFileStoreIndex(count));
+                } else {
+                    // we add a dummy relative path
+                    fileStores.add(null);
+                    relPaths.add("");
+                    fsIndices.add(-1);
+                }
+                ++count;
             }
         }
         return new FileStoreReferenceURIPortObject(uriContents, relPaths,
@@ -251,6 +261,14 @@ public class FileStoreReferenceURIPortObject extends FileStorePortObject
     @Override
     public URIPortObjectSpec getSpec() {
         return m_uriPortObjectSpec;
+    }
+    
+    public String getRelativePath(int index) {
+        return m_relPaths.get(index);
+    }
+    
+    public Integer getFileStoreIndex(int index) {
+        return m_fsIndices.get(index);
     }
 
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/DockerCommandGenerator.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/DockerCommandGenerator.java
@@ -22,11 +22,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 import org.knime.core.node.NodeLogger;
 
+import com.genericworkflownodes.knime.GenericNodesPlugin;
 import com.genericworkflownodes.knime.cliwrapper.CLIElement;
 import com.genericworkflownodes.knime.cliwrapper.CLIMapping;
 import com.genericworkflownodes.knime.config.INodeConfiguration;
@@ -36,7 +37,6 @@ import com.genericworkflownodes.knime.parameter.FileListParameter;
 import com.genericworkflownodes.knime.parameter.FileParameter;
 import com.genericworkflownodes.knime.parameter.ListParameter;
 import com.genericworkflownodes.knime.parameter.Parameter;
-import com.genericworkflownodes.knime.GenericNodesPlugin;
 /**
  * Implements a Docker tool specific generation of a command line.
  * 

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalDockerToolExecutor.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/LocalDockerToolExecutor.java
@@ -18,21 +18,20 @@
  */
 package com.genericworkflownodes.knime.execution.impl;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.io.File;
 
+import com.genericworkflownodes.knime.GenericNodesPlugin;
 import com.genericworkflownodes.knime.config.INodeConfiguration;
 import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
 import com.genericworkflownodes.knime.custom.config.NoBinaryAvailableException;
 import com.genericworkflownodes.knime.execution.IToolExecutor;
 import com.genericworkflownodes.knime.execution.ToolExecutionFailedException;
-import com.genericworkflownodes.knime.execution.impl.LocalToolExecutor.StreamGobbler;
 import com.genericworkflownodes.util.Helper;
 import com.genericworkflownodes.util.StringUtils;
-import com.genericworkflownodes.knime.GenericNodesPlugin;
 
 public class LocalDockerToolExecutor extends LocalToolExecutor implements IToolExecutor {
     

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -29,12 +29,10 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.filefilter.EmptyFileFilter;
 import org.knime.base.filehandling.mime.MIMEMap;
 import org.knime.base.node.util.exttool.ExtToolOutputNodeModel;
 import org.knime.core.data.uri.IURIPortObject;
 import org.knime.core.data.uri.URIContent;
-import org.knime.core.data.uri.URIPortObject;
 import org.knime.core.data.uri.URIPortObjectSpec;
 import org.knime.core.node.ExecutionContext;
 import org.knime.core.node.InvalidSettingsException;

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/flow/merger/FileMergerNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/flow/merger/FileMergerNodeModel.java
@@ -23,9 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.knime.core.data.filestore.FileStore;
 import org.knime.core.data.uri.IURIPortObject;
-import org.knime.core.data.uri.URIContent;
 import org.knime.core.data.uri.URIPortObjectSpec;
 import org.knime.core.node.CanceledExecutionException;
 import org.knime.core.node.ExecutionContext;
@@ -38,7 +36,6 @@ import org.knime.core.node.port.PortObject;
 import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
 
-import com.genericworkflownodes.knime.base.data.port.AbstractFileStoreURIPortObject;
 import com.genericworkflownodes.knime.base.data.port.FileStoreReferenceURIPortObject;
 import com.genericworkflownodes.util.MIMETypeHelper;
 
@@ -92,26 +89,6 @@ public class FileMergerNodeModel extends NodeModel {
         incomingPorts.add((IURIPortObject) inData[0]);
         incomingPorts.add((IURIPortObject) inData[1]);
         // transform to new FileStoreReferenceURIPortObject
-//        List<URIContent> uriContents = new ArrayList<URIContent>();
-//        List<String> relPaths = new ArrayList<String>();
-//        List<Integer> fsIndices = new ArrayList<Integer>();
-//        List<FileStore> fileStores = new ArrayList<FileStore>();
-//
-//        for (IURIPortObject po : incomingPorts) {
-//            uriContents.addAll(po.getURIContents());
-//            if (po instanceof AbstractFileStoreURIPortObject) {
-//                AbstractFileStoreURIPortObject afspo = (AbstractFileStoreURIPortObject) po;
-//                relPaths.addAll(afspo.getRelativePaths());
-//                fileStores.add(afspo.getInternalFileStore());
-//                fsIndices.add(fileStores.size() - 1);
-//            } else {
-//                // we add a dummy relative path
-//                relPaths.add("");
-//                fsIndices.add(-1);
-//            }
-//        }
-//        return new FileStoreReferenceURIPortObject(uriContents, relPaths,
-//                fsIndices, fileStores);
         return new PortObject[] { FileStoreReferenceURIPortObject
                 .create(incomingPorts) };
     }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/flow/merger/FileMergerNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/flow/merger/FileMergerNodeModel.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.knime.core.data.filestore.FileStore;
 import org.knime.core.data.uri.IURIPortObject;
+import org.knime.core.data.uri.URIContent;
 import org.knime.core.data.uri.URIPortObjectSpec;
 import org.knime.core.node.CanceledExecutionException;
 import org.knime.core.node.ExecutionContext;
@@ -36,6 +38,7 @@ import org.knime.core.node.port.PortObject;
 import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
 
+import com.genericworkflownodes.knime.base.data.port.AbstractFileStoreURIPortObject;
 import com.genericworkflownodes.knime.base.data.port.FileStoreReferenceURIPortObject;
 import com.genericworkflownodes.util.MIMETypeHelper;
 
@@ -89,6 +92,26 @@ public class FileMergerNodeModel extends NodeModel {
         incomingPorts.add((IURIPortObject) inData[0]);
         incomingPorts.add((IURIPortObject) inData[1]);
         // transform to new FileStoreReferenceURIPortObject
+//        List<URIContent> uriContents = new ArrayList<URIContent>();
+//        List<String> relPaths = new ArrayList<String>();
+//        List<Integer> fsIndices = new ArrayList<Integer>();
+//        List<FileStore> fileStores = new ArrayList<FileStore>();
+//
+//        for (IURIPortObject po : incomingPorts) {
+//            uriContents.addAll(po.getURIContents());
+//            if (po instanceof AbstractFileStoreURIPortObject) {
+//                AbstractFileStoreURIPortObject afspo = (AbstractFileStoreURIPortObject) po;
+//                relPaths.addAll(afspo.getRelativePaths());
+//                fileStores.add(afspo.getInternalFileStore());
+//                fsIndices.add(fileStores.size() - 1);
+//            } else {
+//                // we add a dummy relative path
+//                relPaths.add("");
+//                fsIndices.add(-1);
+//            }
+//        }
+//        return new FileStoreReferenceURIPortObject(uriContents, relPaths,
+//                fsIndices, fileStores);
         return new PortObject[] { FileStoreReferenceURIPortObject
                 .create(incomingPorts) };
     }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/flow/splitter/FileSplitterNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/flow/splitter/FileSplitterNodeModel.java
@@ -22,8 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import org.knime.core.data.uri.IURIPortObject;
 import org.knime.core.data.uri.URIContent;
@@ -39,8 +37,6 @@ import org.knime.core.node.NodeSettingsWO;
 import org.knime.core.node.port.PortObject;
 import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
-
-import com.genericworkflownodes.knime.base.data.port.FileStoreReferenceURIPortObject;
 
 /**
  * This is the model implementation of FileMerger. This nodes takes two files

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/io/dirimporter/MimeDirectoryImporterNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/io/dirimporter/MimeDirectoryImporterNodeModel.java
@@ -67,18 +67,10 @@ import org.knime.base.filehandling.remote.files.RemoteFile;
 import org.knime.base.filehandling.remote.files.RemoteFileFactory;
 import org.knime.base.node.io.listfiles.ListFiles.Filter;
 import org.knime.base.util.WildcardMatcher;
-import org.knime.core.data.DataColumnSpec;
-import org.knime.core.data.DataColumnSpecCreator;
-import org.knime.core.data.DataTableSpec;
-import org.knime.core.data.def.BooleanCell;
-import org.knime.core.data.def.DefaultRow;
 import org.knime.core.data.uri.IURIPortObject;
 import org.knime.core.data.uri.URIContent;
-import org.knime.core.data.uri.URIDataCell;
 import org.knime.core.data.uri.URIPortObject;
 import org.knime.core.data.uri.URIPortObjectSpec;
-import org.knime.core.node.BufferedDataContainer;
-import org.knime.core.node.BufferedDataTable;
 import org.knime.core.node.CanceledExecutionException;
 import org.knime.core.node.ExecutionContext;
 import org.knime.core.node.ExecutionMonitor;
@@ -90,8 +82,6 @@ import org.knime.core.node.port.PortObject;
 import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
 import org.knime.core.util.MutableInteger;
-
-import com.genericworkflownodes.util.MIMETypeHelper;
 
 /**
  * This is the model implementation.

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/PreferenceInitializer.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/preferences/PreferenceInitializer.java
@@ -22,7 +22,6 @@ import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import com.genericworkflownodes.knime.GenericNodesPlugin;
-import com.genericworkflownodes.util.Helper;
 /**
  * Initializer for the GKN preferences.
  * 


### PR DESCRIPTION
I basically needed to allow the creation of FileStoreReferenceURIPortObjects from themselves.
Otherwise you can not stack FileMergers.
We even could think of extending the number of InputPorts, so you need less mergers.
This is helpful if you need a lot of workflow branches with different settings (e.g. searches for different modifications in OpenMS).
But it is not critical, at some point you should use a loop that accesses a table of modifications specified for each iteration anyway.

Do not merge yet. It will receive some cleanups.