### PR TITLE
[FIX] Reworked the handling of activeness of optional outports. 

### DIFF
--- a/com.genericworkflownodes.knime.config/src/com/genericworkflownodes/knime/config/reader/handler/ParamHandler.java
+++ b/com.genericworkflownodes.knime.config/src/com/genericworkflownodes/knime/config/reader/handler/ParamHandler.java
@@ -364,12 +364,6 @@ public class ParamHandler extends DefaultHandler {
         boolean isInputPort = TYPE_INPUT_FILE.equals(attr_type)
         		|| getTags(attributes).contains(INPUTFILE_TAG)
         		|| TYPE_INPUT_PREFIX.equals(attr_type);
-        
-        // TODO maybe this is a misuse of MimeTypes. But otherwise we need to change the objects and methods
-        // to save/load settings.
-        if (p.isOptional() && !isInputPort) {
-        	p.addMimeType("Inactive");
-        }
 
         String description = attributes.getValue(ATTR_DESCRIPTION);
         p.setDescription(description);

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeDialog.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeDialog.java
@@ -93,11 +93,15 @@ public class GenericKnimeNodeDialog extends NodeDialogPane {
         }
 
         int[] selectedPorts = mtc.getSelectedTypes();
+        boolean[] activePorts = mtc.getActiveness();
 
         for (int i = 0; i < config.getNumberOfOutputPorts(); i++) {
             settings.addInt(
                     GenericKnimeNodeModel.GENERIC_KNIME_NODES_OUTTYPE_PREFIX
                             + i, selectedPorts[i]);
+            settings.addBoolean(
+                    GenericKnimeNodeModel.GENERIC_KNIME_NODES_OUT_ACTIVE
+                            + i, activePorts[i]);
         }
     }
 
@@ -126,6 +130,7 @@ public class GenericKnimeNodeDialog extends NodeDialogPane {
 
         int nP = config.getNumberOfOutputPorts();
         int[] selectedPorts = new int[nP];
+        boolean[] activePorts = new boolean[nP];
 
         for (int i = 0; i < nP; i++) {
             try {
@@ -133,10 +138,15 @@ public class GenericKnimeNodeDialog extends NodeDialogPane {
                         .getInt(GenericKnimeNodeModel.GENERIC_KNIME_NODES_OUTTYPE_PREFIX
                                 + i);
                 selectedPorts[i] = idx;
+                boolean active = settings
+                        .getBoolean(GenericKnimeNodeModel.GENERIC_KNIME_NODES_OUT_ACTIVE
+                                + i);
+                activePorts[i] = active;
             } catch (InvalidSettingsException e) {
                 throw new NotConfigurableException(e.getMessage(), e);
             }
         }
         mtc.setSelectedTypes(selectedPorts);
+        mtc.setActivePorts(activePorts);
     }
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -212,9 +212,6 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         for (int i = 0; i < ports.size(); i++) {
             if (ports.get(i).isOptional()) {
                 portTypes[i] = OPTIONAL_PORT_TYPE;
-                //if (!ports.get(i).isActive()) {
-                //    portTypes[i] = InactiveBranchPortObject.TYPE;
-                //}
             }
         }
         return portTypes;
@@ -482,12 +479,10 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         for (int i = 0; i < nOut; i++) {
             // selected output MIMEType
             int selectedMIMETypeIndex = getOutputTypeIndex(i);
-            // TODO: check
             String mt = m_fileEndingsOutPorts[i][selectedMIMETypeIndex];
             if (!isInactive(i)) {
                 out_spec[i] = new URIPortObjectSpec(mt);
             } else {
-                
                 out_spec[i] = InactiveBranchPortObjectSpec.INSTANCE;
             }
         }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -83,7 +83,7 @@ import com.genericworkflownodes.util.Helper;
  */
 public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
     static final String GENERIC_KNIME_NODES_OUTTYPE_PREFIX = "GENERIC_KNIME_NODES_outtype#";
-    static final String GENERIC_KNIME_NODES_OUT_ACTIVE = "GENERIC_KNIME_NODES_active#";
+    static final String GENERIC_KNIME_NODES_OUT_ACTIVE = "GENERIC_KNIME_NODES_outport_active#";
     
     private static final NodeLogger LOGGER = NodeLogger
             .getLogger(GenericKnimeNodeModel.class);

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -83,7 +83,8 @@ import com.genericworkflownodes.util.Helper;
  */
 public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
     static final String GENERIC_KNIME_NODES_OUTTYPE_PREFIX = "GENERIC_KNIME_NODES_outtype#";
-
+    static final String GENERIC_KNIME_NODES_OUT_ACTIVE = "GENERIC_KNIME_NODES_active#";
+    
     private static final NodeLogger LOGGER = NodeLogger
             .getLogger(GenericKnimeNodeModel.class);
 
@@ -97,6 +98,11 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
      * for each output port.
      */
     protected int[] m_selectedOutputType;
+    
+    /**
+     * Contains information on which output ports are active.
+     */
+    protected boolean[] m_activeOutputPorts;
 
     /**
      * stores the node configuration (i.e. parameters, ports, ..)
@@ -147,22 +153,13 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         Helper.array2dcopy(fileEndingsInPorts, m_fileEndingsInPorts);
 
         m_fileEndingsOutPorts = new String[fileEndingsOutPorts.length][];
-        //Special treatment of outports. If they are optional, an inactive mimetype is allowed.
-        for (int i = 0; i < fileEndingsOutPorts.length; ++i) {
-            int array_length = fileEndingsOutPorts[i].length;
-            if (nodeConfig.getOutputPorts().get(i).isOptional()) {
-                array_length++;
-            }
-            
-            m_fileEndingsOutPorts[i] = new String[array_length];
-            System.arraycopy(fileEndingsOutPorts[i], 0, m_fileEndingsOutPorts[i], 0, fileEndingsOutPorts[i].length);
-            if (nodeConfig.getOutputPorts().get(i).isOptional()) {
-                m_fileEndingsOutPorts[i][array_length-1] = "Inactive";
-            }
-            
-        }
+        Helper.array2dcopy(fileEndingsOutPorts, m_fileEndingsOutPorts);
 
         m_selectedOutputType = new int[m_nodeConfig.getNumberOfOutputPorts()];
+        m_activeOutputPorts = new boolean[m_nodeConfig.getNumberOfOutputPorts()];
+        for (int i = 0; i < m_activeOutputPorts.length; i++){
+            m_activeOutputPorts[i] = true; //default to true during creation of the node.
+        }
     }
 
     /**
@@ -197,8 +194,10 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
      * @return If the port is inactive.
      */
     protected boolean isInactive(int idx) {
-        return this.getOutputType(idx).equals("Inactive");
+        return !m_activeOutputPorts[idx];
     }
+
+
 
     /**
      * Creates a list of output port types for the nodes.
@@ -213,9 +212,9 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         for (int i = 0; i < ports.size(); i++) {
             if (ports.get(i).isOptional()) {
                 portTypes[i] = OPTIONAL_PORT_TYPE;
-                if (!ports.get(i).isActive()) {
-                    portTypes[i] = InactiveBranchPortObject.TYPE;
-                }
+                //if (!ports.get(i).isActive()) {
+                //    portTypes[i] = InactiveBranchPortObject.TYPE;
+                //}
             }
         }
         return portTypes;
@@ -316,6 +315,8 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         for (int i = 0; i < m_nodeConfig.getNumberOfOutputPorts(); i++) {
             settings.addInt(GENERIC_KNIME_NODES_OUTTYPE_PREFIX + i,
                     getOutputTypeIndex(i));
+            settings.addBoolean(GENERIC_KNIME_NODES_OUT_ACTIVE + i,
+                    !isInactive(i));
         }
     }
 
@@ -326,7 +327,7 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
     protected void loadValidatedSettingsFrom(final NodeSettingsRO settings)
             throws InvalidSettingsException {
         // - we know that values are validated and thus are valid
-        // - we xfer the values into the corresponding model objects
+        // - we transfer the values into the corresponding model objects
         for (String key : m_nodeConfig.getParameterKeys()) {
             // FileParameters are not set by the UI
             if (m_nodeConfig.getParameter(key) instanceof IFileParameter)
@@ -345,6 +346,9 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
         for (int i = 0; i < m_nodeConfig.getNumberOfOutputPorts(); i++) {
             int idx = settings.getInt(GENERIC_KNIME_NODES_OUTTYPE_PREFIX + i);
             m_selectedOutputType[i] = idx;
+            boolean active = settings.getBoolean(GENERIC_KNIME_NODES_OUT_ACTIVE + i);
+            m_activeOutputPorts[i] = active;
+            m_nodeConfig.getOutputPorts().get(i).setActive(active); 
         }
     }
 
@@ -480,9 +484,10 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
             int selectedMIMETypeIndex = getOutputTypeIndex(i);
             // TODO: check
             String mt = m_fileEndingsOutPorts[i][selectedMIMETypeIndex];
-            if (!mt.toLowerCase().equals("inactive")) {
+            if (!isInactive(i)) {
                 out_spec[i] = new URIPortObjectSpec(mt);
             } else {
+                
                 out_spec[i] = InactiveBranchPortObjectSpec.INSTANCE;
             }
         }
@@ -603,9 +608,8 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
                             "Cannot determine number of output files if no input file is given.");
                 }
                 
-                //if MimeType is "Inactive" just create Empty FileStore(Prefix)URIPortObjects
                 PortObject fsupo;
-                if (!ext.toLowerCase().equals("inactive")) {
+                if (port.isActive()) {
 
                     fsupo = new FileStoreURIPortObject(
                             exec.createFileStore(m_nodeConfig.getName() + "_" + i));
@@ -631,7 +635,7 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
             } else if (p instanceof FileParameter && !port.isMultiFile()) {
                 //if MimeType is "Inactive" just create Empty FileStore(Prefix)URIPortObjects
                 PortObject po;
-                if (!ext.toLowerCase().equals("inactive")) {
+                if (port.isActive()) {
                     // if we have no basename to use (e.g., Node without input-file)
                     // we use the nodename
                     String basename;

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/dialogs/mimetype_dialog/MimeTypeChooserDialog.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/dialogs/mimetype_dialog/MimeTypeChooserDialog.java
@@ -19,15 +19,17 @@
 
 package com.genericworkflownodes.knime.generic_node.dialogs.mimetype_dialog;
 
+import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
 
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-
-import org.jdesktop.swingx.VerticalLayout;
 
 import com.genericworkflownodes.knime.config.INodeConfiguration;
 import com.genericworkflownodes.knime.port.Port;
@@ -38,42 +40,83 @@ public class MimeTypeChooserDialog extends JPanel implements ActionListener {
     private INodeConfiguration config;
 
     private JComboBox[] cbs;
+    private JCheckBox[] chbs;
     private int[] sel_ports;
+    private boolean[] active_ports;
 
     public MimeTypeChooserDialog(INodeConfiguration config) {
         this.config = config;
-
-        setLayout(new VerticalLayout());
-
         int nCB = this.config.getNumberOfOutputPorts();
+        
+        // Outer=full panel
+        setLayout(new BorderLayout());
 
+        // Inner panel with row for each port
+        JPanel portPanel = new JPanel();
+        portPanel.setLayout(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        
         cbs = new JComboBox[nCB];
+        chbs = new JCheckBox[nCB];
         sel_ports = new int[nCB];
+        active_ports = new boolean[nCB];
 
         for (int i = 0; i < nCB; i++) {
+            // row
+            c.gridy = i;
             Port port = this.config.getOutputPorts().get(i);
-
-            this.add(new JLabel(port.getName()));
             
+            // name label
+            c.gridx = 0;
+            c.weightx = 0.2;
+            c.anchor = GridBagConstraints.WEST;
+            c.fill = GridBagConstraints.HORIZONTAL;
+            portPanel.add(new JLabel(port.getName()),c);
+            
+            // collect types
             List<String> types = port.getMimeTypes();
-            
             String[] strs = new String[types.size()];
-            
             int idx = 0;
-            
             for (String type : types) {
                 strs[idx++] = type;
             }
-
+            
+            // type combo box
             JComboBox cb = new JComboBox(strs);
             cbs[i] = cb;
-            this.add(cb);
+            c.gridx++;
+            c.weightx = 0.6;
+            portPanel.add(cb,c);
             cb.addActionListener(this);
+            
+            // Active? label
+            c.gridx++;
+            c.weightx = 0.1;
+            c.fill = GridBagConstraints.NONE;
+            c.anchor = GridBagConstraints.EAST;
+            portPanel.add(new JLabel("Active?"),c);
+            
+            // Activeness checkbox
+            JCheckBox chb = new JCheckBox();
+            chb.setSelected(true);
+            if(!port.isOptional()){
+                chb.setEnabled(false); // Do not change required inputs
+            }
+            chbs[i] = chb;
+            c.gridx++;
+            c.anchor = GridBagConstraints.CENTER;
+            portPanel.add(chb,c);
+            chb.addActionListener(this);
         }
+        // To align to the top of the outer BorderLayout
+        this.add(portPanel, BorderLayout.NORTH);
     }
 
     public int[] getSelectedTypes() {
         return sel_ports;
+    }
+    public boolean[] getActiveness() {
+        return active_ports;
     }
 
     public void setSelectedTypes(int[] sel_ports) {
@@ -83,12 +126,25 @@ public class MimeTypeChooserDialog extends JPanel implements ActionListener {
             cbs[i].setSelectedIndex(sel_ports[i]);
         }
     }
+    
+    public void setActivePorts(boolean[] act_ports) {
+        this.active_ports = new boolean[act_ports.length];
+        System.arraycopy(act_ports, 0, this.active_ports, 0, act_ports.length);
+        for (int i = 0; i < chbs.length; i++) {
+            chbs[i].setSelected(act_ports[i]);
+        }
+    }
 
     @Override
     public void actionPerformed(ActionEvent ev) {
         for (int i = 0; i < cbs.length; i++) {
             if (ev.getSource() == cbs[i]) {
                 sel_ports[i] = cbs[i].getSelectedIndex();
+            }
+        }
+        for (int i = 0; i < chbs.length; i++) {
+            if (ev.getSource() == chbs[i]) {
+                active_ports[i] = chbs[i].isSelected();
             }
         }
 


### PR DESCRIPTION
Use additional boolean instead of the Inactive mimetypes.
Avoids a lot of problems with special handling of that mimetype.
But will result in warnings for every node when you update your plugin (because of the missing additional bool setting for each port that is now saved to settings.xml during saving).