### PR TITLE
[Feature] Versioned dynamic nodes

### DIFF
--- a/com.genericworkflownodes.knime/plugin.xml
+++ b/com.genericworkflownodes.knime/plugin.xml
@@ -6,6 +6,7 @@
    <extension-point id="com.genericworkflownodes.knime.mime.demangler.Demangler" name="Demangler" schema="schema/com.genericworkflownodes.knime.mime.demangler.Demangler.exsd"/>
    <extension-point id="com.genericworkflownodes.knime.execution.CommandGenerator" name="CommandGenerator" schema="schema/com.genericworkflownodes.knime.execution.CommandGenerator.exsd"/>
    <extension-point id="com.genericworkflownodes.knime.execution.Executor" name="Executor" schema="schema/com.genericworkflownodes.knime.execution.Executor.exsd"/>
+   <extension-point id="com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory" name="VersionedNodeSetFactory" schema="schema/com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory.exsd"/>
    
    <extension point="org.knime.workbench.repository.categories">
     <category description="/community/GenericKnimeNodes" icon="icons/category.png" level-id="GenericKnimeNodes" name="GenericKnimeNodes" path="/community"/>
@@ -141,5 +142,12 @@
                serializerClass="com.genericworkflownodes.knime.base.data.port.PortObjectHandlerCellSerializer">
          </serializer>
       </DataType>
+   </extension>
+   <extension
+         point="org.knime.workbench.repository.nodesets">
+      <nodeset
+            deprecated="false"
+            factory-class="com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactoryManager">
+      </nodeset>
    </extension>
 </plugin>

--- a/com.genericworkflownodes.knime/schema/com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory.exsd
+++ b/com.genericworkflownodes.knime/schema/com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory.exsd
@@ -1,0 +1,109 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="com.genericworkflownodes.knime" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="com.genericworkflownodes.knime" id="com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory" name="VersionedNodeSetFactory"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice minOccurs="1" maxOccurs="unbounded">
+            <element ref="versionednodesetfactory"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="versionednodesetfactory">
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.knime.core.node.NodeSetFactory"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="version" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Semantic versioning of the registered NodeSetFactory
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/com.genericworkflownodes.knime/schema/com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory.exsd
+++ b/com.genericworkflownodes.knime/schema/com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory.exsd
@@ -55,15 +55,8 @@
                   
                </documentation>
                <appinfo>
-                  <meta.attribute kind="java" basedOn=":org.knime.core.node.NodeSetFactory"/>
+                  <meta.attribute kind="java" basedOn=":com.genericworkflownodes.knime.dynamic.GenericNodeSetFactory"/>
                </appinfo>
-            </annotation>
-         </attribute>
-         <attribute name="version" type="string" use="required">
-            <annotation>
-               <documentation>
-                  Semantic versioning of the registered NodeSetFactory
-               </documentation>
             </annotation>
          </attribute>
       </complexType>

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/BinaryManager.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/BinaryManager.java
@@ -20,6 +20,7 @@ package com.genericworkflownodes.knime.custom.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -221,16 +222,14 @@ public final class BinaryManager {
         ArrayList<String> files = new ArrayList<>();
         Path p;
         try {
-            p = Paths.get(FileLocator.toFileURL(bundle.getResource(DESCRIPTORS_PATH)).toURI());
+            p = Paths.get(FileLocator.toFileURL(bundle.getResource(DESCRIPTORS_PATH)).toString());
         } catch (Exception ex) {
             return Collections.emptyList();
         }
         while (e.hasMoreElements()){
             try {
-                Path el = Paths.get(FileLocator.toFileURL(e.nextElement()).toURI());
+                Path el = Paths.get(FileLocator.toFileURL(e.nextElement()).toString());
                 files.add(p.relativize(el).toString());
-            } catch (URISyntaxException e1) {
-                throw new AssertionError("Should not happen", e1);
             } catch (IOException e1) {
                 e1.printStackTrace();
             }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/BinaryManager.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/BinaryManager.java
@@ -20,7 +20,12 @@ package com.genericworkflownodes.knime.custom.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +52,12 @@ public final class BinaryManager {
     /**
      * Path inside the bundle where the binaries should be located.
      */
-    private static final String BUNDLE_PATH = "payload";
+    private static final String BUNDLE_PATH = "payload";    
+    
+    /**
+     * Path inside the bundle where the descriptors should be located.
+     */
+    private static final String DESCRIPTORS_PATH = BUNDLE_PATH + File.separator + "descriptors";
 
     /**
      * File that should be present to identify the correct path.
@@ -162,6 +172,16 @@ public final class BinaryManager {
             return null;
         }
     }
+    
+    public File resolveToolDescriptorPath(final String relToolPath) {
+        Bundle bundle = FrameworkUtil.getBundle(classInBundle);
+        try {
+            return new File(FileLocator.toFileURL(bundle.getResource(DESCRIPTORS_PATH + File.separator + relToolPath)).getFile());
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            return null;
+        }
+    }
 
     /**
      * Search the bundle for the given file name.
@@ -187,5 +207,34 @@ public final class BinaryManager {
                 return null;
             }
         }
+    }
+    
+    /**
+     * Search the bundle for CTDs and list them in a List of Files.
+     * 
+     * @return List of CTD Files in the bundle
+     * @throws URISyntaxException 
+     */
+    public Iterable<String> listTools() {
+        Bundle bundle = FrameworkUtil.getBundle(classInBundle);
+        Enumeration<URL> e = bundle.findEntries(DESCRIPTORS_PATH, "*.ctd", true);
+        ArrayList<String> files = new ArrayList<>();
+        Path p;
+        try {
+            p = Paths.get(FileLocator.toFileURL(bundle.getResource(DESCRIPTORS_PATH)).toURI());
+        } catch (Exception ex) {
+            return Collections.emptyList();
+        }
+        while (e.hasMoreElements()){
+            try {
+                Path el = Paths.get(FileLocator.toFileURL(e.nextElement()).toURI());
+                files.add(p.relativize(el).toString());
+            } catch (URISyntaxException e1) {
+                throw new AssertionError("Should not happen", e1);
+            } catch (IOException e1) {
+                e1.printStackTrace();
+            }
+        }
+        return files;
     }
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IPluginConfiguration.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IPluginConfiguration.java
@@ -78,4 +78,11 @@ public interface IPluginConfiguration {
      * @return
      */
     String getDockerMachine();
+
+    /**
+     *  The version of the plugin
+     *  
+     * @return
+     */
+    String getPluginVersion();
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/impl/PluginConfiguration.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/impl/PluginConfiguration.java
@@ -22,6 +22,10 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
 
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
 import com.genericworkflownodes.knime.custom.config.BinaryManager;
 import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
 
@@ -69,6 +73,11 @@ public class PluginConfiguration implements IPluginConfiguration {
     private final String m_dockerMachine;
     
     /**
+     * The version
+     */
+     private final String m_version;
+    
+    /**
      * C'tor for {@link PluginConfiguration}.
      * 
      * @param pluginId
@@ -87,22 +96,24 @@ public class PluginConfiguration implements IPluginConfiguration {
         m_pluginId = pluginId;
         m_pluginName = pluginName;
         m_props = props;
+        Bundle bundle = FrameworkUtil.getBundle(classFromPlugin);
+        m_version = bundle.getVersion().toString();
         m_binaryManager = new BinaryManager(classFromPlugin);
         Properties p = new Properties();
         Map<String,Properties> toolMap = new Hashtable<String,Properties>(); 
-        for(String key: m_props.stringPropertyNames()){
-            if(key.startsWith("tool.")){
+        for (String key: m_props.stringPropertyNames()) {
+            if (key.startsWith("tool.")) {
                 String value = m_props.getProperty(key);
                 p.put(key, value);
                 String[] keyElements = key.split("\\.");
-                if(keyElements.length > 2){
+                if (keyElements.length > 2) {
                     String tool_key = "";
-                    for(int i=2;i<keyElements.length;i++){
+                    for (int i=2; i<keyElements.length; i++) {
                         tool_key+=keyElements[i];
                     }
-                    if(toolMap.containsKey(keyElements[1])){
+                    if (toolMap.containsKey(keyElements[1])) {
                         toolMap.get(keyElements[1]).put(tool_key, value);
-                    }else{
+                    } else {
                         Properties p_tool = new Properties();
                         p_tool.put(tool_key, value);
                         toolMap.put(keyElements[1], p_tool);
@@ -114,6 +125,15 @@ public class PluginConfiguration implements IPluginConfiguration {
         m_specifcToolProps = toolMap;
         m_dockerMachine = props.getProperty("dockerMachine","default");
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getPluginVersion() {
+        return m_version;
+    }
+
 
     /**
      * {@inheritDoc}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeFactory.java
@@ -51,18 +51,14 @@ public abstract class DynamicGenericNodeFactory
     
     public static final String ID_CFG_KEY = "id";
 
+    public static final String DEPRECATION_CFG_KEY = "deprecated";
+    
     private static final NodeLogger logger = NodeLogger.getLogger(DynamicGenericNodeFactory.class);
     
     private String m_id;
     private String m_ctdFile;
     private INodeConfiguration m_config;
-    
-    /**
-     * Implement this method and return the configuration of the plugin
-     * the nodes are hosted in.
-     * @return the plugin configuration.
-     */
-    protected abstract IPluginConfiguration getPluginConfig();
+    private boolean m_isDeprecated = false;
     
     protected String getIconPath() {
         return "";
@@ -70,6 +66,11 @@ public abstract class DynamicGenericNodeFactory
     
     public String getId() {
         return m_id;
+    }
+    
+    @Override
+    public boolean isDeprecated() {
+        return m_isDeprecated;
     }
     
     /**
@@ -148,6 +149,9 @@ public abstract class DynamicGenericNodeFactory
             throws InvalidSettingsException {
         m_ctdFile = config.getString(CTD_FILE_CFG_KEY);
         m_id = config.getString(ID_CFG_KEY);
+        if (config.containsKey(DEPRECATION_CFG_KEY)) {
+            m_isDeprecated = config.getBoolean(DEPRECATION_CFG_KEY);
+        }
         super.loadAdditionalFactorySettings(config);
     }
     
@@ -155,6 +159,7 @@ public abstract class DynamicGenericNodeFactory
     public void saveAdditionalFactorySettings(ConfigWO config) {
         config.addString(CTD_FILE_CFG_KEY, m_ctdFile);
         config.addString(ID_CFG_KEY, m_id);
+        config.addBoolean(DEPRECATION_CFG_KEY, m_isDeprecated);
         super.saveAdditionalFactorySettings(config);
     }
     
@@ -167,7 +172,7 @@ public abstract class DynamicGenericNodeFactory
             
             // Node
             KnimeNode node = doc.addNewKnimeNode();
-            node.setName(cfg.getExecutableName());
+            node.setName(cfg.getName());
             node.setIcon(getIconPath());
             node.setType(KnimeNode.Type.MANIPULATOR);
             
@@ -224,7 +229,7 @@ public abstract class DynamicGenericNodeFactory
     }
     
     private InputStream getConfigAsStream() throws FileNotFoundException { 
-        return new FileInputStream(DynamicGenericNodeSetFactory.resolveSourceFile(getClass(), m_ctdFile));
+        return new FileInputStream(getPluginConfig().getBinaryManager().resolveToolDescriptorPath(m_ctdFile));
     }
     
     private String mimetypes2String(List<String> mt) {
@@ -238,5 +243,7 @@ public abstract class DynamicGenericNodeFactory
         mimetypes.append("]");
         return mimetypes.toString();
     }
+
+    protected abstract IPluginConfiguration getPluginConfig();
    
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeFactory.java
@@ -41,8 +41,7 @@ import com.genericworkflownodes.knime.port.Port;
  * 
  * @author Fillbrunn, Alexander
  */
-public abstract class DynamicGenericNodeFactory
-    extends DynamicNodeFactory<DynamicGenericNodeModel> {
+public abstract class DynamicGenericNodeFactory extends GenericNodeFactory {
     
     /**
      * The configuration key for the ctd file.
@@ -50,15 +49,18 @@ public abstract class DynamicGenericNodeFactory
     public static final String CTD_FILE_CFG_KEY = "ctdFile";
     
     public static final String ID_CFG_KEY = "id";
+    
+    public static final String NSFID_CFG_KEY = "nsfid";
 
     public static final String DEPRECATION_CFG_KEY = "deprecated";
     
     private static final NodeLogger logger = NodeLogger.getLogger(DynamicGenericNodeFactory.class);
     
+    private String m_nsfid;
     private String m_id;
     private String m_ctdFile;
     private INodeConfiguration m_config;
-    private boolean m_isDeprecated = false;
+    private boolean m_deprecated;
     
     protected String getIconPath() {
         return "";
@@ -66,11 +68,6 @@ public abstract class DynamicGenericNodeFactory
     
     public String getId() {
         return m_id;
-    }
-    
-    @Override
-    public boolean isDeprecated() {
-        return m_isDeprecated;
     }
     
     /**
@@ -130,7 +127,6 @@ public abstract class DynamicGenericNodeFactory
     public boolean hasDialog() {
         return true;
     }
-
     /**
      * {@inheritDoc}
      */
@@ -149,8 +145,13 @@ public abstract class DynamicGenericNodeFactory
             throws InvalidSettingsException {
         m_ctdFile = config.getString(CTD_FILE_CFG_KEY);
         m_id = config.getString(ID_CFG_KEY);
-        if (config.containsKey(DEPRECATION_CFG_KEY)) {
-            m_isDeprecated = config.getBoolean(DEPRECATION_CFG_KEY);
+        m_nsfid = config.getString(NSFID_CFG_KEY);
+        try {
+            m_deprecated = VersionedNodeSetFactoryManager.isFactoryDeprecated(m_nsfid);
+        } catch (InterruptedException e) {
+            // This means that loading the nodes was interrupted.
+            // We simply leave the node non-deprecated.
+            logger.error(e);
         }
         super.loadAdditionalFactorySettings(config);
     }
@@ -159,7 +160,7 @@ public abstract class DynamicGenericNodeFactory
     public void saveAdditionalFactorySettings(ConfigWO config) {
         config.addString(CTD_FILE_CFG_KEY, m_ctdFile);
         config.addString(ID_CFG_KEY, m_id);
-        config.addBoolean(DEPRECATION_CFG_KEY, m_isDeprecated);
+        config.addString(NSFID_CFG_KEY, m_nsfid);
         super.saveAdditionalFactorySettings(config);
     }
     
@@ -172,6 +173,7 @@ public abstract class DynamicGenericNodeFactory
             
             // Node
             KnimeNode node = doc.addNewKnimeNode();
+            node.setDeprecated(m_deprecated);
             node.setName(cfg.getName());
             node.setIcon(getIconPath());
             node.setType(KnimeNode.Type.MANIPULATOR);
@@ -243,7 +245,4 @@ public abstract class DynamicGenericNodeFactory
         mimetypes.append("]");
         return mimetypes.toString();
     }
-
-    protected abstract IPluginConfiguration getPluginConfig();
-   
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeModel.java
@@ -415,7 +415,7 @@ public class DynamicGenericNodeModel extends ExtToolOutputNodeModel {
             URIPortObjectSpec spec = (URIPortObjectSpec) inSpecs[i];
 
             // get MIMEType from incoming port
-            // TODO: we should check all file extensions, if its more then one
+            // TODO: we should check all file extensions, if its more than one
             String mt = MIMEMap.getMIMEType(spec.getFileExtensions().get(0));
 
             // check whether input MIMEType is in list of allowed MIMETypes

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeSetFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeSetFactory.java
@@ -19,6 +19,7 @@ import org.knime.core.node.NodeSettings;
 import org.knime.core.node.config.ConfigRO;
 
 import com.genericworkflownodes.knime.config.reader.CTDConfigurationReader;
+import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
 
 public abstract class DynamicGenericNodeSetFactory implements NodeSetFactory {
 
@@ -30,38 +31,36 @@ public abstract class DynamicGenericNodeSetFactory implements NodeSetFactory {
      * that loads nodes from CTD files in the given source folder.
      * @param folder the source folder to search for CTDs in.
      */
-    public DynamicGenericNodeSetFactory(String folder) {
-        m_folder = folder;
-        m_folderFile = resolveSourceFile(getClass(), folder);
+    public DynamicGenericNodeSetFactory() {
     }
     
-    private File m_folderFile;
-    private String m_folder;
     private Map<String, String> m_idToFile;
+    private boolean m_isDeprecated;
     
     /**
      * @return The class of the node factory to use.
      */
     protected abstract Class<? extends DynamicGenericNodeFactory> getNodeFactory();
     
+    /**
+     * Implement this method and return the configuration of the plugin
+     * the nodes are hosted in.
+     * @return the plugin configuration.
+     */
+    protected abstract IPluginConfiguration getPluginConfig();
+    
     protected abstract String getCategoryPath();
-
-    static File resolveSourceFile(Class<?> clazz, String relPath) {
-        return Paths.get(clazz
-                .getProtectionDomain()
-                .getCodeSource()
-                .getLocation()
-                .getPath(), relPath).toFile();
-    }
     
     protected abstract String getIdForTool(String relPath);
+    
+    
     
     @Override
     public Collection<String> getNodeFactoryIds() {
         if (m_idToFile == null) {
             m_idToFile = new LinkedHashMap<>();
 
-            for (File f : FileUtils.listFiles(m_folderFile, CTD_EXT, true)) {
+/*            for (File f : FileUtils.listFiles(m_folderFile, CTD_EXT, true)) {
                 if (f.isFile()) {
                     String name = f.getName();
                     if (name.endsWith(".xml") && !name.equals("config.xml")) {
@@ -72,6 +71,9 @@ public abstract class DynamicGenericNodeSetFactory implements NodeSetFactory {
                     String p = parent.relativize(filePath).toString();
                     m_idToFile.put(getIdForTool(p), p);
                 }
+            }*/
+            for (String s : getPluginConfig().getBinaryManager().listTools()) {
+                m_idToFile.put(getIdForTool(s), s);
             }
         }
         return m_idToFile.keySet();
@@ -85,14 +87,14 @@ public abstract class DynamicGenericNodeSetFactory implements NodeSetFactory {
     @Override
     public String getCategoryPath(String id) {
         String category;
-        File f = Paths.get(m_folderFile.getAbsolutePath()).resolve(m_idToFile.get(id)).toAbsolutePath().toFile();
+        File f = getPluginConfig().getBinaryManager().resolveToolDescriptorPath(m_idToFile.get(id));
         try (InputStream cfgStream = new FileInputStream(f)) {
             category = new CTDConfigurationReader().read(cfgStream).getCategory();
         } catch(Exception e) {
             logger.error("Could not read node category from CTD, using '/' instead.", e);
             category = "";
         }
-        return getCategoryPath() + "/" + category;
+        return getCategoryPath() + "/" + category + "/" + getPluginConfig().getPluginVersion();
     }
 
     @Override
@@ -105,8 +107,14 @@ public abstract class DynamicGenericNodeSetFactory implements NodeSetFactory {
         NodeSettings ns = new NodeSettings("");
         ns.addString(DynamicGenericNodeFactory.ID_CFG_KEY, id);
         ns.addString(DynamicGenericNodeFactory.CTD_FILE_CFG_KEY,
-                    Paths.get(m_folder).resolve(m_idToFile.get(id)).toString());
+                m_idToFile.get(id));
+        ns.addBoolean(DynamicGenericNodeFactory.DEPRECATION_CFG_KEY,
+                m_isDeprecated);
         return ns;
+    }
+    
+    public void setIsDeprecated(boolean isDeprecated) {
+        m_isDeprecated = isDeprecated;
     }
 
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/GenericNodeFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/GenericNodeFactory.java
@@ -1,0 +1,17 @@
+package com.genericworkflownodes.knime.dynamic;
+
+import org.knime.core.node.DynamicNodeFactory;
+
+import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
+
+public abstract class GenericNodeFactory
+    extends DynamicNodeFactory<DynamicGenericNodeModel> {
+
+    protected String getIconPath() {
+        return "";
+    }
+    
+    public abstract String getId();
+    
+    protected abstract IPluginConfiguration getPluginConfig();
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/GenericNodeSetFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/GenericNodeSetFactory.java
@@ -1,0 +1,27 @@
+package com.genericworkflownodes.knime.dynamic;
+
+import org.knime.core.node.NodeSetFactory;
+import org.osgi.framework.Version;
+
+import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
+
+public interface GenericNodeSetFactory extends NodeSetFactory {
+    /**
+     * The version of the node's created by this factory.
+     * @return the version
+     */
+    Version getVersion();
+    
+    /**
+     * The ID identifying the group of nodes provided by this factory.
+     * @return an ID that is the same for all factories providing
+     *          versions of the same node set.
+     */
+    String getId();
+    
+    /**
+     * The plugin configuration of this node set factory.
+     * @return the configuration
+     */
+    IPluginConfiguration getPluginConfig();
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactory.java
@@ -62,9 +62,4 @@ public class VersionedNodeSetFactory implements NodeSetFactory {
     public ConfigRO getAdditionalSettings(String id) {
         return m_nodeSetFactory.getAdditionalSettings(removeSuffix(id));
     }
-
-    public void setIsDeprecated(boolean isDeprecated) {
-        m_nodeSetFactory.setIsDeprecated(isDeprecated);
-    }
-
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactory.java
@@ -1,0 +1,70 @@
+package com.genericworkflownodes.knime.dynamic;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.knime.core.node.NodeFactory;
+import org.knime.core.node.NodeModel;
+import org.knime.core.node.NodeSetFactory;
+import org.knime.core.node.config.ConfigRO;
+import org.osgi.framework.Version;
+
+public class VersionedNodeSetFactory implements NodeSetFactory {
+    
+    private final DynamicGenericNodeSetFactory m_nodeSetFactory;
+    private final String m_versionSuffix;
+    private final Version m_version;
+
+    public Version getVersion() {
+        return m_version;
+    }
+
+    public NodeSetFactory getNodeSetFactory() {
+        return m_nodeSetFactory;
+    }
+    
+    public VersionedNodeSetFactory(DynamicGenericNodeSetFactory factory) {
+        m_version = new Version(factory.getPluginConfig().getPluginVersion());
+        m_nodeSetFactory = factory;
+        m_versionSuffix = "_" + factory.getPluginConfig().getPluginVersion().replaceAll("\\.", "_");
+    }
+
+    @Override
+    public Collection<String> getNodeFactoryIds() {
+        ArrayList<String> ids = new ArrayList<>();
+        for (String id : m_nodeSetFactory.getNodeFactoryIds()) {
+            ids.add(id + m_versionSuffix);
+        }
+        return ids;
+    }
+    
+    private String removeSuffix(String id) {
+        return id.substring(0, id.length() - m_versionSuffix.length());
+    }
+
+    @Override
+    public Class<? extends NodeFactory<? extends NodeModel>> getNodeFactory(
+            String id) {
+        return m_nodeSetFactory.getNodeFactory(removeSuffix(id));
+    }
+
+    @Override
+    public String getCategoryPath(String id) {
+        return m_nodeSetFactory.getCategoryPath(removeSuffix(id));
+    }
+
+    @Override
+    public String getAfterID(String id) {
+        return m_nodeSetFactory.getAfterID(removeSuffix(id));
+    }
+
+    @Override
+    public ConfigRO getAdditionalSettings(String id) {
+        return m_nodeSetFactory.getAdditionalSettings(removeSuffix(id));
+    }
+
+    public void setIsDeprecated(boolean isDeprecated) {
+        m_nodeSetFactory.setIsDeprecated(isDeprecated);
+    }
+
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactoryManager.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactoryManager.java
@@ -1,0 +1,134 @@
+package com.genericworkflownodes.knime.dynamic;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
+import org.knime.core.node.NodeFactory;
+import org.knime.core.node.NodeLogger;
+import org.knime.core.node.NodeModel;
+import org.knime.core.node.NodeSetFactory;
+import org.knime.core.node.config.ConfigRO;
+import org.osgi.framework.Version;
+
+public class VersionedNodeSetFactoryManager implements NodeSetFactory {
+
+    List<VersionedNodeSetFactory> m_factories = null;
+    Map<String, VersionedNodeSetFactory> m_idToFac = new HashMap<>();
+    
+    /**
+     * The id of the used extension point.
+     */
+    private static final String EXTENSION_POINT_ID = "com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory";
+
+    /**
+     * The central static logger.
+     */
+    private static final NodeLogger LOGGER = NodeLogger
+            .getLogger(VersionedNodeSetFactoryManager.class);
+    
+    /*
+     * Searchs through the eclipse extension point registry for registered
+     * {@link VersionedNodeSetFactory}s.
+     */
+    public List<VersionedNodeSetFactory> getAvailableVersionedNodeSetFactories() {
+        if (m_factories == null) {
+            m_factories = new ArrayList<VersionedNodeSetFactory>();
+            Map<String, PriorityQueue<VersionedNodeSetFactory>> pluginIDQueues = new HashMap<>();
+            IExtensionRegistry reg = Platform.getExtensionRegistry();
+            IConfigurationElement[] elements = reg
+                    .getConfigurationElementsFor(EXTENSION_POINT_ID);
+            try {
+                for (IConfigurationElement elem : elements) {
+                    final DynamicGenericNodeSetFactory o = (DynamicGenericNodeSetFactory)elem.createExecutableExtension("class");
+                    // cast is guaranteed to work based on the extension point
+                    // definition
+                    VersionedNodeSetFactory versionedFac = new VersionedNodeSetFactory(o);
+                    m_factories.add(versionedFac);
+                    String pluginID = o.getPluginConfig().getPluginId();
+                    if (!pluginIDQueues.containsKey(pluginID)) {
+                        pluginIDQueues.put(pluginID, new PriorityQueue<VersionedNodeSetFactory>(10,new Comparator<VersionedNodeSetFactory>(){
+
+                            @Override
+                            public int compare(VersionedNodeSetFactory o1,
+                                    VersionedNodeSetFactory o2) {
+                                return o1.getVersion().compareTo(o2.getVersion());
+                            }
+                            
+                        }));
+                    }
+                    pluginIDQueues.get(pluginID).add(versionedFac);
+                    for (String nodeID : versionedFac.getNodeFactoryIds()) {
+                        if (m_idToFac.containsKey(nodeID)) {
+                            LOGGER.warn("Node with ID " + nodeID + " already registered");
+                        }
+                        m_idToFac.put(nodeID, versionedFac);
+                    }
+                }
+                
+                for (PriorityQueue<VersionedNodeSetFactory> q : pluginIDQueues.values()) {
+                    q.poll(); //Newest version stays undeprecated
+                    for (VersionedNodeSetFactory f : q) {
+                        f.setIsDeprecated(true);
+                    }
+                }
+            } catch (CoreException e) {
+                LOGGER.warn(e.getMessage());
+            }
+        }
+        return m_factories;
+    }
+    
+    @Override
+    public Collection<String> getNodeFactoryIds() {
+        ArrayList<String> totalFactories = new ArrayList<>();
+        for (VersionedNodeSetFactory fac : getAvailableVersionedNodeSetFactories()) {
+            totalFactories.addAll(fac.getNodeFactoryIds());
+        }
+        return totalFactories;
+    }
+
+    @Override
+    public Class<? extends NodeFactory<? extends NodeModel>> getNodeFactory(
+            String id) {
+        VersionedNodeSetFactory fac = getFactory(id);
+        return fac.getNodeFactory(id);
+    }
+
+    @Override
+    public String getCategoryPath(String id) {
+        VersionedNodeSetFactory fac = getFactory(id);
+        return fac.getCategoryPath(id);
+    }
+
+    @Override
+    public String getAfterID(String id) {
+        VersionedNodeSetFactory fac = getFactory(id);
+        return fac.getAfterID(id);
+    }
+
+    @Override
+    public ConfigRO getAdditionalSettings(String id) {
+        VersionedNodeSetFactory fac = getFactory(id);
+        return fac.getAdditionalSettings(id);
+    }
+
+    private VersionedNodeSetFactory getFactory(String id) {
+        VersionedNodeSetFactory fac = m_idToFac.get(id);
+        if (fac == null) {
+            throw new IllegalArgumentException("Node with ID " + id + " is not registered.");
+        }
+        return fac;
+    }
+
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactoryManager.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/VersionedNodeSetFactoryManager.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.PriorityQueue;
 import java.util.Set;
 
@@ -19,17 +19,17 @@ import org.knime.core.node.NodeLogger;
 import org.knime.core.node.NodeModel;
 import org.knime.core.node.NodeSetFactory;
 import org.knime.core.node.config.ConfigRO;
-import org.osgi.framework.Version;
 
 public class VersionedNodeSetFactoryManager implements NodeSetFactory {
 
-    List<VersionedNodeSetFactory> m_factories = null;
-    Map<String, VersionedNodeSetFactory> m_idToFac = new HashMap<>();
+    List<GenericNodeSetFactory> m_factories = null;
+    Map<String, GenericNodeSetFactory> m_idToFac = new HashMap<>();
     
     /**
      * The id of the used extension point.
      */
-    private static final String EXTENSION_POINT_ID = "com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory";
+    private static final String EXTENSION_POINT_ID =
+            "com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory";
 
     /**
      * The central static logger.
@@ -41,46 +41,46 @@ public class VersionedNodeSetFactoryManager implements NodeSetFactory {
      * Searchs through the eclipse extension point registry for registered
      * {@link VersionedNodeSetFactory}s.
      */
-    public List<VersionedNodeSetFactory> getAvailableVersionedNodeSetFactories() {
+    public synchronized List<GenericNodeSetFactory> getAvailableVersionedNodeSetFactories() {
         if (m_factories == null) {
-            m_factories = new ArrayList<VersionedNodeSetFactory>();
-            Map<String, PriorityQueue<VersionedNodeSetFactory>> pluginIDQueues = new HashMap<>();
+            m_factories = new ArrayList<GenericNodeSetFactory>();
+            Map<String, PriorityQueue<GenericNodeSetFactory>> pluginIDQueues = new HashMap<>();
             IExtensionRegistry reg = Platform.getExtensionRegistry();
             IConfigurationElement[] elements = reg
                     .getConfigurationElementsFor(EXTENSION_POINT_ID);
             try {
                 for (IConfigurationElement elem : elements) {
-                    final DynamicGenericNodeSetFactory o = (DynamicGenericNodeSetFactory)elem.createExecutableExtension("class");
+                    final GenericNodeSetFactory o = (GenericNodeSetFactory)elem.createExecutableExtension("class");
                     // cast is guaranteed to work based on the extension point
                     // definition
-                    VersionedNodeSetFactory versionedFac = new VersionedNodeSetFactory(o);
-                    m_factories.add(versionedFac);
+                    m_factories.add(o);
                     String pluginID = o.getPluginConfig().getPluginId();
                     if (!pluginIDQueues.containsKey(pluginID)) {
-                        pluginIDQueues.put(pluginID, new PriorityQueue<VersionedNodeSetFactory>(10,new Comparator<VersionedNodeSetFactory>(){
-
+                        pluginIDQueues.put(pluginID, new PriorityQueue<GenericNodeSetFactory>(10, new Comparator<GenericNodeSetFactory>(){
                             @Override
-                            public int compare(VersionedNodeSetFactory o1,
-                                    VersionedNodeSetFactory o2) {
-                                return o1.getVersion().compareTo(o2.getVersion());
+                            public int compare(GenericNodeSetFactory o1,
+                                    GenericNodeSetFactory o2) {
+                                return o2.getVersion().compareTo(o1.getVersion());
                             }
-                            
                         }));
                     }
-                    pluginIDQueues.get(pluginID).add(versionedFac);
-                    for (String nodeID : versionedFac.getNodeFactoryIds()) {
+                    pluginIDQueues.get(pluginID).add(o);
+                    for (String nodeID : o.getNodeFactoryIds()) {
                         if (m_idToFac.containsKey(nodeID)) {
                             LOGGER.warn("Node with ID " + nodeID + " already registered");
                         }
-                        m_idToFac.put(nodeID, versionedFac);
+                        m_idToFac.put(nodeID, o);
                     }
                 }
                 
-                for (PriorityQueue<VersionedNodeSetFactory> q : pluginIDQueues.values()) {
-                    q.poll(); //Newest version stays undeprecated
-                    for (VersionedNodeSetFactory f : q) {
-                        f.setIsDeprecated(true);
-                    }
+                for (PriorityQueue<GenericNodeSetFactory> q : pluginIDQueues.values()) {
+                    //Newest version stays undeprecated
+                    GenericNodeSetFactory latest = q.poll();
+                    m_nondeprecatedFactories.add(latest.getId());
+                }
+                synchronized (m_nondeprecatedFactories) {
+                    m_loaded = true;
+                    m_nondeprecatedFactories.notifyAll();
                 }
             } catch (CoreException e) {
                 LOGGER.warn(e.getMessage());
@@ -89,10 +89,23 @@ public class VersionedNodeSetFactoryManager implements NodeSetFactory {
         return m_factories;
     }
     
+    private static boolean m_loaded = false;
+    private static Set<String> m_nondeprecatedFactories = new HashSet<>();
+    
+    public static boolean isFactoryDeprecated(String id) throws InterruptedException {
+        // We need to wait here until all nodes are loaded to determine which ones are deprecated
+        synchronized (m_nondeprecatedFactories) {
+            while (!m_loaded) {
+                m_nondeprecatedFactories.wait();
+            }
+        }
+        return !m_nondeprecatedFactories.contains(id);
+    }
+    
     @Override
     public Collection<String> getNodeFactoryIds() {
         ArrayList<String> totalFactories = new ArrayList<>();
-        for (VersionedNodeSetFactory fac : getAvailableVersionedNodeSetFactories()) {
+        for (GenericNodeSetFactory fac : getAvailableVersionedNodeSetFactories()) {
             totalFactories.addAll(fac.getNodeFactoryIds());
         }
         return totalFactories;
@@ -101,30 +114,30 @@ public class VersionedNodeSetFactoryManager implements NodeSetFactory {
     @Override
     public Class<? extends NodeFactory<? extends NodeModel>> getNodeFactory(
             String id) {
-        VersionedNodeSetFactory fac = getFactory(id);
+        GenericNodeSetFactory fac = getFactory(id);
         return fac.getNodeFactory(id);
     }
 
     @Override
     public String getCategoryPath(String id) {
-        VersionedNodeSetFactory fac = getFactory(id);
+        GenericNodeSetFactory fac = getFactory(id);
         return fac.getCategoryPath(id);
     }
 
     @Override
     public String getAfterID(String id) {
-        VersionedNodeSetFactory fac = getFactory(id);
+        GenericNodeSetFactory fac = getFactory(id);
         return fac.getAfterID(id);
     }
 
     @Override
     public ConfigRO getAdditionalSettings(String id) {
-        VersionedNodeSetFactory fac = getFactory(id);
+        GenericNodeSetFactory fac = getFactory(id);
         return fac.getAdditionalSettings(id);
     }
 
-    private VersionedNodeSetFactory getFactory(String id) {
-        VersionedNodeSetFactory fac = m_idToFac.get(id);
+    private GenericNodeSetFactory getFactory(String id) {
+        GenericNodeSetFactory fac = m_idToFac.get(id);
         if (fac == null) {
             throw new IllegalArgumentException("Node with ID " + id + " is not registered.");
         }


### PR DESCRIPTION
First steps towards dynamic versioning of (dynamic) GKN plugins:
- Multiple versions of the same plugin can be installed now and are registered and handled through a new extension point
- Only the nodes of the newest version of the plugin is visible in the node repo as the rest is deprecated.
- If an old node is in a workflow the old version will be used
- Automatic installation mechanism should be working for missing versions of a plugin (to be confirmed)
- Updated the resource lookup mechanism of both the versioned and unversioned dynamicnodesetfactories (e.g. support binaries in platform-specific fragments)

The use of this mechanism is probably not yet stable. For now, stick to static generation in production.
Updates to come. We will test it on a beta update site.