### PR TITLE
[FEATURE] Add dll registry extension point.

### DIFF
--- a/com.genericworkflownodes.knime/plugin.xml
+++ b/com.genericworkflownodes.knime/plugin.xml
@@ -8,6 +8,7 @@
    <extension-point id="com.genericworkflownodes.knime.execution.Executor" name="Executor" schema="schema/com.genericworkflownodes.knime.execution.Executor.exsd"/>
    <extension-point id="com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory" name="VersionedNodeSetFactory" schema="schema/com.genericworkflownodes.knime.dynamic.VersionedNodeSetFactory.exsd"/>
    <extension-point id="com.genericworkflownodes.knime.filesplitter" name="File Splitter" schema="schema/com.genericworkflownodes.knime.filesplitter.exsd"/>
+   <extension-point id="com.genericworkflownodes.knime.custom.config.DLLProvider" name="DLLProvider" schema="schema/com.genericworkflownodes.knime.custom.config.DLLProvider.exsd"/>
 
    <extension point="org.knime.workbench.repository.categories">
     <category description="/community/GenericKnimeNodes" icon="icons/category.png" level-id="GenericKnimeNodes" name="GenericKnimeNodes" path="/community"/>
@@ -86,6 +87,14 @@
       <executor
             class="com.genericworkflownodes.knime.execution.impl.LocalDockerToolExecutor"
             name="com.genericworkflownodes.knime.execution.impl.LocalDockerToolExecutor">
+      </executor>
+      <executor
+            class="com.genericworkflownodes.knime.execution.impl.SeqAnToolExecutor"
+            name="SeqAnToolExecutor">
+      </executor>
+      <executor
+            class="com.genericworkflownodes.knime.execution.impl.SeqAnToolExecutor"
+            name="com.genericworkflownodes.knime.execution.impl.SeqAnToolExecutor">
       </executor>
    </extension>
    <extension

--- a/com.genericworkflownodes.knime/schema/com.genericworkflownodes.knime.custom.config.DLLProvider.exsd
+++ b/com.genericworkflownodes.knime/schema/com.genericworkflownodes.knime.custom.config.DLLProvider.exsd
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="com.genericworkflownodes.knime" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="com.genericworkflownodes.knime" id="com.genericworkflownodes.custom.config.DLLProvider" name="DLLProvider"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <choice>
+            <element ref="dllprovider"/>
+         </choice>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="dllprovider">
+      <complexType>
+         <attribute name="class" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":com.genericworkflownodes.knime.custom.config.IDLLProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/BinaryManager.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/BinaryManager.java
@@ -208,47 +208,54 @@ public final class BinaryManager {
             }
         }
     }
-    
+
     public boolean fileExists(final String fileName) {
         return findFileInBundle(fileName) != null;
     }
-    
+
     /**
      * Search the bundle for CTDs and list them in a List of Files.
-     * 
+     *
      * @return List of CTD Files in the bundle
-     * @throws URISyntaxException 
+     * @throws URISyntaxException
      */
     public Iterable<String> listTools() {
         Bundle bundle = FrameworkUtil.getBundle(classInBundle);
         Enumeration<URL> ctds = bundle.findEntries(DESCRIPTORS_PATH, "*.ctd", true);
-        
+
         // findEntries returns null if no entry is found
         if (ctds == null) {
             LOGGER.warn("The bundle " + bundle.getSymbolicName() + " does not contain any CTD files.");
             return Collections.emptyList();
         }
-        
+
         ArrayList<String> files = new ArrayList<>();
         Path p;
         try {
-            p = Paths.get(FileLocator.toFileURL(bundle.getResource(DESCRIPTORS_PATH)).toString());
+            p = Paths.get(FileLocator
+                    .toFileURL(bundle.getResource(DESCRIPTORS_PATH)).toURI());
             LOGGER.debug("Descriptors location: " + p.toString());
         } catch (IOException ex) {
             LOGGER.error(ex);
             return Collections.emptyList();
+        } catch (URISyntaxException ex) {
+            LOGGER.error(ex);
+            return Collections.emptyList();
         }
-        
+
         while (ctds.hasMoreElements()){
             try {
-                Path el = Paths.get(FileLocator.toFileURL(ctds.nextElement()).toString());
+                Path el = Paths
+                        .get(FileLocator.toFileURL(ctds.nextElement()).toURI());
                 LOGGER.info("Loading CTD from " + el.toString());
                 files.add(p.relativize(el).toString());
             } catch (IOException e) {
                 LOGGER.error(e);
+            } catch (URISyntaxException e) {
+                LOGGER.error(e);
             }
         }
-        
+
         return files;
     }
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/DLLRegistry.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/DLLRegistry.java
@@ -1,0 +1,91 @@
+package com.genericworkflownodes.knime.custom.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
+import org.knime.core.node.NodeLogger;
+
+public class DLLRegistry {
+
+	/**
+	 * The id of the used extension point.
+	 */
+    private static final String EXTENSION_POINT_ID = "com.genericworkflownodes.knime.custom.config.DLLProvider";
+
+	/**
+	 * The central static logger.
+	 */
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(DLLRegistry.class);
+
+	/*
+	 * Default constructor
+	 */
+	private DLLRegistry() {
+	}
+
+    /**
+     * Initialization-on-demand holder idiom holder for the DllRegistry
+     * instance.
+     *
+     */
+    private static class LazyHolder {
+        private static final DLLRegistry INSTANCE = new DLLRegistry();
+    }
+
+    /**
+     * Gets the instance of this class.
+     *
+     * @return An instance of this class.
+     */
+    public static DLLRegistry getDLLRegistry() {
+        return LazyHolder.INSTANCE;
+    }
+
+    /**
+     * Searches all extensions for registered dlls.
+     *
+     * @return A list of paths ({@link String}), or an empty list if no dll was
+     *         found.
+     */
+    public List<String> getAvailableDLLs() throws CoreException {
+
+        Set<String> dllPaths = new HashSet<String>();
+
+		IExtensionRegistry reg = Platform.getExtensionRegistry();
+		IConfigurationElement[] elements = reg.getConfigurationElementsFor(EXTENSION_POINT_ID);
+
+        for (IConfigurationElement elem : elements) {
+            final Object o = elem.createExecutableExtension("class");
+            // cast is guaranteed to work based on the extension point
+            // definition
+            for (File f : ((IDLLProvider) o).getDLLs()) {
+                try {
+                    String path = f.getCanonicalFile().getParent();
+
+                    if (path != null && !path.isEmpty()
+                            && !dllPaths.contains(path)) {
+                        dllPaths.add(path);
+                    }
+                } catch (IOException e) {
+                    LOGGER.warn("The path of the dll could not be resolved ["
+                            + f.toString() + "]" + e.getMessage());
+                }
+			}
+		}
+
+        if (dllPaths.isEmpty()) {
+            return new ArrayList<String>();
+        }
+
+        return new ArrayList<String>(dllPaths);
+	}
+
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IDLLProvider.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IDLLProvider.java
@@ -1,0 +1,21 @@
+package com.genericworkflownodes.knime.custom.config;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Provides access to globally stored DLLs shared by multiple plug-ins, in order
+ * to keep the size of the shipped binaries low.
+ *
+ * @author rmaerker
+ *
+ */
+public interface IDLLProvider {
+
+	/**
+	 * Returns a list of all DLLs contained in the bundle.
+	 *
+	 * @return A {@link List} of DLL {@link File}s in the current bundle.
+	 */
+    List<File> getDLLs();
+}

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/SeqAnToolExecutor.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/execution/impl/SeqAnToolExecutor.java
@@ -1,0 +1,64 @@
+package com.genericworkflownodes.knime.execution.impl;
+
+import java.io.File;
+
+import org.eclipse.core.runtime.CoreException;
+import org.knime.core.node.NodeLogger;
+
+import com.genericworkflownodes.knime.custom.config.DLLRegistry;
+
+/**
+ * A local tool executor for SeqAn nodes that need to register external dlls for
+ * the windows binaries.
+ *
+ * @author rmaerker
+ *
+ */
+public class SeqAnToolExecutor extends LocalToolExecutor {
+
+    /**
+     * NodeLogger used for this executor.
+     */
+    protected static final NodeLogger LOGGER = NodeLogger
+            .getLogger(SeqAnToolExecutor.class);
+
+    /**
+     * The default constructor.
+     */
+    public SeqAnToolExecutor() {
+        super();
+    }
+
+    @Override
+    protected void setupProcessEnvironment(ProcessBuilder builder) {
+        super.setupProcessEnvironment(builder);
+
+        // Get the dlls from the DLLRegistry.
+        String dll_paths = "";
+        try {
+            for (String dll_path : DLLRegistry.getDLLRegistry()
+                    .getAvailableDLLs()) {
+                dll_paths += dll_path + File.pathSeparator;
+            }
+        } catch (CoreException e) {
+            LOGGER.error("Could not extract dll search paths.", e);
+            return;
+        }
+
+        // We would expect the dlls only on Windows.
+        if (dll_paths.isEmpty())
+            return;
+
+        if (!m_environmentVariables.containsKey("Path")) {
+            LOGGER.warn(
+                    "Not setting dll search paths! Expected Path environment on Windows systems!");
+            return;
+        }
+
+        String path_key = "Path";
+        m_environmentVariables.put(path_key,
+                expandEnvironmentVariables(m_environmentVariables.get(path_key))
+                        + File.pathSeparator
+                        + dll_paths);
+    }
+}


### PR DESCRIPTION
Adds a dll registry to the GKN, which registers dlls  shared between many generic nodes in a global registry. 
It also adds the SeqAn executor which overrides the setup of the execution environment to inject into the path environment the paths to the identified dlls.

I will test this on a windows machine first. Still you can review it already but wait for merging until I can confirm that it works on windows platforms.