### PR TITLE
[FEATURE] Adds display layer for plugin version.

### DIFF
--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IPluginConfiguration.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/custom/config/IPluginConfiguration.java
@@ -21,23 +21,34 @@ package com.genericworkflownodes.knime.custom.config;
 
 import java.util.Properties;
 
+import org.osgi.framework.Version;
+
 /**
  * Provides all plugin specific configuration settings.
- * 
+ *
  * @author aiche, schubert
  */
 public interface IPluginConfiguration {
 
     /**
+     * Declares the possible layers for adding the version information of the
+     * plug-in. This can be either in the category pane of the node explorer or
+     * on the node level within the node name or nowhere.
+     */
+    enum VersionDisplayLayer {
+    NONE, NODE, CATEGORY
+    }
+
+    /**
      * The id of the plugin.
-     * 
+     *
      * @return The name of the configured plugin.
      */
     String getPluginId();
 
     /**
      * General properties of the plugin.
-     * 
+     *
      * @return A {@link Properties} object containing additional properties of
      *         the plugin.
      */
@@ -45,44 +56,58 @@ public interface IPluginConfiguration {
 
     /**
      * The name of the plugin as it would be shown in the GUI.
-     * 
+     *
      * @return
      */
     String getPluginName();
 
     /**
      * Gives access to the binary manager, responsible for the current plugin.
-     * 
+     *
      * @return The binary manager for this plugin.
      */
     BinaryManager getBinaryManager();
-    
+
     /**
      *  The tool specific properties
-     *  
+     *
      *  @return
      */
-    Properties getToolProperties(); 
-    
+    Properties getToolProperties();
+
     /**
      * Specific tool properties
-     * 
+     *
      * @param toolName - The name of the tool
-     * @return 
+     * @return
      */
     Properties getToolProperty(String toolName);
-    
+
     /**
      *  The name of the docker-machine to use
-     *  
+     *
      * @return
      */
     String getDockerMachine();
 
     /**
      *  The version of the plugin
-     *  
+     *
      * @return
      */
     String getPluginVersion();
+
+    /**
+     * The raw version of the plugin.
+     *
+     * @return {@link Version}
+     */
+    Version getRawPluginVersion();
+
+    /**
+     * An enum representing the version display layer.
+     *
+     * @return {
+     */
+    VersionDisplayLayer getVersionDisplayLayer();
 }

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeSetFactory.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/dynamic/DynamicGenericNodeSetFactory.java
@@ -17,11 +17,12 @@ import org.osgi.framework.Version;
 
 import com.genericworkflownodes.knime.config.reader.CTDConfigurationReader;
 import com.genericworkflownodes.knime.custom.config.IPluginConfiguration;
+import com.genericworkflownodes.knime.custom.config.IPluginConfiguration.VersionDisplayLayer;
 
 public abstract class DynamicGenericNodeSetFactory implements GenericNodeSetFactory {
 
     private static final NodeLogger logger = NodeLogger.getLogger(DynamicGenericNodeSetFactory.class);
-    
+
     /**
      * Creates a new <code>DynamicGenericNodeSetFactory</code>
      * that loads nodes from CTD files in the given source folder.
@@ -31,26 +32,27 @@ public abstract class DynamicGenericNodeSetFactory implements GenericNodeSetFact
         Version v = getVersion();
         m_versionSuffix = String.format("_%d_%d_%d", v.getMajor(), v.getMinor(), v.getMicro());
     }
-    
+
     private String m_versionSuffix;
     private Map<String, String> m_idToFile;
-    
+
     /**
      * @return The class of the node factory to use.
      */
     protected abstract Class<? extends GenericNodeFactory> getNodeFactory();
-    
+
     /**
      * Implement this method and return the configuration of the plugin
      * the nodes are hosted in.
      * @return the plugin configuration.
      */
+    @Override
     public abstract IPluginConfiguration getPluginConfig();
-    
+
     protected abstract String getCategoryPath();
-    
+
     protected abstract String getIdForTool(String relPath);
-    
+
     @Override
     public Collection<String> getNodeFactoryIds() {
         if (m_idToFile == null) {
@@ -77,7 +79,13 @@ public abstract class DynamicGenericNodeSetFactory implements GenericNodeSetFact
             logger.error("Could not read node category from CTD, using '/' instead.", e);
             category = "";
         }
-        return getCategoryPath() + "/" + getPluginConfig().getPluginVersion() + "/" + category;
+
+        if (getPluginConfig()
+                .getVersionDisplayLayer() == VersionDisplayLayer.CATEGORY) {
+            return getCategoryPath() + "/" + getPluginConfig().getPluginVersion() + "/" + category;
+        } else {
+            return getCategoryPath() + "/" + category;
+        }
     }
 
     @Override


### PR DESCRIPTION
Adds a property to the plugin.properties called `versionDisplayLayer` which can be set to either `category` or `node` and changes the behaviour of where the version number of a plugin is displayed. 
Either on the category layer or the node layer. 
Adapted the IPluginConfiguration to return the raw Version object for extraction of the version components. 