### PR TITLE
Adapt version ranges

### DIFF
--- a/com.genericworkflownodes.knime.gpl3nodes/META-INF/MANIFEST.MF
+++ b/com.genericworkflownodes.knime.gpl3nodes/META-INF/MANIFEST.MF
@@ -8,11 +8,11 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.knime.base;bundle-version="[3.0.0,5.0.0)",
  org.knime.core;bundle-version="[3.0.0,5.0.0)",
  org.knime.core.data.uritype;bundle-version="[3.0.0,5.0.0)",
- com.genericworkflownodes.knime.config;bundle-version="[0.8.0,2.0.0)",
+ com.genericworkflownodes.knime.config;bundle-version="1.0.0",
  org.knime.base.filehandling;bundle-version="[3.1.0,5.0.0)",
  org.apache.commons.lang;bundle-version="[2.4.0,3.0.0)",
- org.apache.commons.httpclient;bundle-version="3.1.0",
- com.genericworkflownodes.knime;bundle-version="[0.8.0,2.0.0)"
+ org.apache.commons.httpclient;bundle-version="[3.1.0,4.0.0)",
+ com.genericworkflownodes.knime;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.genericworkflownodes.knime.nodes.io.dirimporter,

--- a/com.genericworkflownodes.knime.tests/META-INF/MANIFEST.MF
+++ b/com.genericworkflownodes.knime.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for GKN base plugin
 Bundle-SymbolicName: com.genericworkflownodes.knime.tests;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Freie Universitaet Berlin, Universitaet Tuebingen, and the GenericWorkflowNodes Team
-Fragment-Host: com.genericworkflownodes.knime;bundle-version="0.8.0"
+Fragment-Host: com.genericworkflownodes.knime;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.knime.testing;bundle-version="[3.0.0,5.0.0)",
  org.junit;bundle-version="[4.8.2,5.0.0)"

--- a/com.genericworkflownodes.knime/META-INF/MANIFEST.MF
+++ b/com.genericworkflownodes.knime/META-INF/MANIFEST.MF
@@ -11,11 +11,11 @@ Bundle-Vendor: Freie Universitaet Berlin, Universitaet Tuebingen, and the Generi
 Require-Bundle: org.eclipse.ui;bundle-version="[3.107.0,4.0.0)",
  org.knime.base;bundle-version="[3.0.0,5.0.0)",
  org.knime.core.data.uritype;bundle-version="[3.0.0,5.0.0)",
- com.genericworkflownodes.knime.config;bundle-version="0.8.0",
+ com.genericworkflownodes.knime.config;bundle-version="1.0.0",
  org.knime.base.filehandling;bundle-version="[3.1.0,5.0.0)",
  org.apache.commons.lang;bundle-version="[2.4.0,3.0.0)",
- org.apache.commons.httpclient;bundle-version="3.1.0",
- org.apache.log4j
+ org.apache.commons.httpclient;bundle-version="[3.1.0,4.0.0)",
+ org.apache.log4j;bundle-version="[1.2.14,2.0.0)"
 Export-Package: com.genericworkflownodes.knime.base.data.port,
  com.genericworkflownodes.knime.commandline,
  com.genericworkflownodes.knime.commandline.impl,


### PR DESCRIPTION
Fixes them to the same version of GKN for every GKN interdependency.
Extends external dependencies to be more future proof. CI will complain if something breaks. Until then, allow minor version updates.