### PR TITLE
fix [issue#259]

### DIFF
--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/generic_node/GenericKnimeNodeModel.java
@@ -629,7 +629,7 @@ public abstract class GenericKnimeNodeModel extends ExtToolOutputNodeModel {
                 // if we have no basename to use (e.g., Node without input-file)
                 // we use the nodename
                 String basename;
-                if (basenames.isEmpty()) {
+                if (basenames.isEmpty() || basenames.get(0) == null) {
                     basename = m_nodeConfig.getName();
                 } else {
                     basename = basenames.get(0);


### PR DESCRIPTION
 use the node name as basename for nodes with an input-file that is null (no input file given)