### PR TITLE
Feature/directory loader with relative path

### DIFF
--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/io/dirloader/DirectoryLoaderNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/nodes/io/dirloader/DirectoryLoaderNodeModel.java
@@ -43,7 +43,6 @@ import org.knime.core.node.port.PortObjectSpec;
 import org.knime.core.node.port.PortType;
 import org.knime.core.util.FileUtil;
 
-//import com.genericworkflownodes.knime.base.data.port.IPrefixURIPortObject;
 import com.genericworkflownodes.knime.base.data.port.PrefixURIPortObject;
 
 /**


### PR DESCRIPTION
Allow workflow relative path and variables as Input for Directory Loader Node by using
`FileUtil.getFileFromURL()`