### PR TITLE
[FIX] Use SimpleFSCell instead of abstract and unregistered SerializableFSCell.

### DIFF
--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/base/data/port/SimpleFileStoreCell.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/base/data/port/SimpleFileStoreCell.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.knime.core.data.DataCellDataInput;
 import org.knime.core.data.DataCellDataOutput;
+import org.knime.core.data.DataType;
 import org.knime.core.data.filestore.FileStore;
 
 /**
@@ -15,6 +16,11 @@ import org.knime.core.data.filestore.FileStore;
  */
 public class SimpleFileStoreCell extends SerializableFileStoreCell {
 
+    /**
+     * The cell type.
+     */
+    public static final DataType TYPE = DataType.getType(SimpleFileStoreCell.class);
+    
     private static final long serialVersionUID = 1L;
     private List<String> m_relativePaths;
     

--- a/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/cluster/nodes/porttofilestore/PortToFileStoreNodeModel.java
+++ b/com.genericworkflownodes.knime/src/com/genericworkflownodes/knime/cluster/nodes/porttofilestore/PortToFileStoreNodeModel.java
@@ -156,7 +156,7 @@ public class PortToFileStoreNodeModel extends NodeModel {
     }
     
     private DataTableSpec createSpec() {
-        DataColumnSpec spec = new DataColumnSpecCreator("files", SerializableFileStoreCell.TYPE).createSpec();
+        DataColumnSpec spec = new DataColumnSpecCreator("files", SimpleFileStoreCell.TYPE).createSpec();
         return new DataTableSpecCreator()
                 .addColumns(spec)
                 .createSpec();


### PR DESCRIPTION
We encountered errors when loading saved workflows from disk.
```
DataLoadError Port To FileCells
2020-11-30 13:39:14,787 : WARN  : ModalContext :  : FileNodePersistor : Port to File Cells : 6:61:0:11:12 : Unable to load port content for node "Port to File Cells": Data cell implementation 'com.genericworkflownodes.knime.base.data.port.SerializableFileStoreCell' not found.
```

I hope that fixes it. I could not reproduce it in my local SDK.
